### PR TITLE
F-002: architecture audit (build graph → docs/ARCHITECTURE.md)

### DIFF
--- a/AGENTS.md
+++ b/AGENTS.md
@@ -1,0 +1,51 @@
+# Forma autonomous worker instructions
+
+Repo: `formatools/forma` (local: `/Users/claw/work/forma`)
+
+## Mission
+
+Ship Forma as a **working Android product**, then **forma-core** extraction, then **JVM**, then **Bazel**. Full vision: `docs/VISION.md`. Prioritized work: `TICKETS.md`.
+
+## Hard rules
+
+1. Work **only** from `TICKETS.md` priority order. Pick the top `todo` / continue `in_progress` ticket.
+2. Prefer small, reviewable changes. One ticket slice per 4h run when possible.
+3. After functional changes: update `README.md` if user-facing; append `docs/PROGRESS.md`.
+4. Keep files under ~1000 lines; split rather than grow blobs.
+5. Do **not** create new cron jobs from a cron run.
+6. Do **not** force-push `master` on upstream. Prefer branch + PR to `formatools/forma` (or stepango fork if permissions require).
+7. Ground reports in tool output (builds, git, gh). Never invent green builds.
+8. If JDK/Android SDK missing, work F-001 first (install Temurin 17+ via brew/sdkman; document exact commands in PROGRESS).
+
+## Git workflow
+
+```bash
+cd /Users/claw/work/forma
+git fetch origin
+git checkout -B forma/F-XXX-short-slug origin/master   # or continue existing branch
+# ... implement ...
+git status && git diff
+# commit with message: "F-XXX: concise summary"
+# push and open PR when slice is meaningful
+```
+
+## Verify
+
+- Prefer `./gradlew` in `plugins/` and `application/` (not system gradle).
+- Capture last 30–50 lines of failures into PROGRESS notes.
+- If build cannot run (no JDK), say so clearly and only do non-build work that still advances tickets (docs/architecture) after attempting F-001.
+
+## Progress bookkeeping
+
+Every run must:
+
+1. Read `TICKETS.md` + last entries of `docs/PROGRESS.md`
+2. Update ticket status
+3. Append a dated section to `docs/PROGRESS.md` with: ticket id, actions, commits/PRs, blockers, next step
+4. Final cron response = short human report (what moved, PR links, blockers)
+
+## Out of scope for workers
+
+- Unrelated personal tasks, email, grkr
+- Large rewrites without a ticket
+- Reordering the priority list without user instruction

--- a/README.md
+++ b/README.md
@@ -97,6 +97,10 @@ androidLibrary(
 )
 ```
 
+## Development environment
+
+Worker / contributor host setup (JDK 17+, Android SDK platform 33): see [`docs/ENV.md`](docs/ENV.md) and `source scripts/env-mac.sh`.
+
 ## Progress
 
 | Supported target types | implemented |            purpose            | validation |

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -1,0 +1,78 @@
+# Forma prioritized tickets
+
+Status legend: `todo` | `in_progress` | `blocked` | `done`
+
+Update this file when picking or finishing work. Cron workers must pick the **highest priority open ticket** that is not blocked.
+
+## P0 — Bootstrap (Android product baseline)
+
+| ID | Status | Title | Notes |
+|----|--------|-------|-------|
+| F-001 | done | Environment bootstrap: JDK + Android SDK tooling on worker host | OpenJDK 17 + cmdline-tools; see `docs/ENV.md`, `scripts/env-mac.sh`. plugins/app/includer/depgen build green on host |
+| F-002 | todo | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
+| F-003 | todo | Get plugins + sample `application/` building on modern toolchain | Host already green with current AGP 8.1.2 / Gradle 8.3–8.4; ticket may shrink to CI/modernization only |
+| F-004 | todo | CI green on GitHub Actions for plugins + application | Fix `.github/workflows` |
+
+## P1 — Android working product
+
+| ID | Status | Title | Notes |
+|----|--------|-------|-------|
+| F-010 | todo | Document strict dependency matrix from live code (not only README) | Source of truth from validators/targets |
+| F-011 | todo | Tighten validation for `api` / `impl` (Dagger2-friendly boundaries) | Align with current types; related GH #56, #18 |
+| F-012 | todo | External deps catalog UX + tooling polish | `plugins/deps` catalog generators |
+| F-013 | todo | Compose support for Android library/ui targets | GH #96 |
+| F-014 | todo | Sample app: gold-standard multi-feature structure | Home/characters already present; modernize |
+| F-015 | todo | Android project tutorial (getting started) | GH #53 |
+| F-016 | todo | Plugin publish path (Portal user + target publish config) | GH #132, #133 |
+| F-017 | todo | Configuration-time performance pass | GH #106, #42 |
+
+## P2 — forma-core extraction
+
+| ID | Status | Title | Notes |
+|----|--------|-------|-------|
+| F-020 | todo | Design forma-core public API (types, restrictions, validation, target registry) | Write `docs/forma-core-api.md` first |
+| F-021 | todo | Extract dependency-type / restriction engine into `forma-core` | Related GH #39, closed #34 |
+| F-022 | todo | Extract validation framework into `forma-core` | Keep Android validators as plugins |
+| F-023 | todo | Wire Android implementation as first consumer of forma-core | Sample still builds |
+| F-024 | todo | Publish/coordinate coordinates: `tools.forma:core` vs android plugins | |
+
+## P3 — JVM applications
+
+| ID | Status | Title | Notes |
+|----|--------|-------|-------|
+| F-030 | todo | JVM target set on forma-core (`library`, `api`, `impl`, `utils`, tests) | |
+| F-031 | todo | JVM sample application | |
+| F-032 | todo | Docs: JVM getting started | |
+
+## P4 — Bazel
+
+| ID | Status | Title | Notes |
+|----|--------|-------|-------|
+| F-040 | todo | Design Bazel adapter mapping (targets ↔ rules, visibility ↔ deps) | |
+| F-041 | todo | Spike: generate or check Bazel BUILD from forma declarations | |
+| F-042 | todo | Minimal Bazel sample using forma-core concepts | |
+
+## Backlog (lower priority / historical GitHub)
+
+Keep for reference; do not start unless higher tickets done or user prioritizes:
+
+- GH #110 Navigation task cache broken
+- GH #97 Excluded from dependency validation
+- GH #88 BuildFeatures support
+- GH #82 Version code/name in binary
+- GH #77 transitiveDeps extension
+- GH #54 Generate target structure from minimal config
+- GH #51 Support build types
+- GH #46 New navigation system
+- GH #44/#43 Hybrid targets/config examples
+- GH #36 Docs for external plugins
+- GH #126 Target features configuration options
+- GH #111 Gradle project as buildscript classpath
+- GH #103 Java 8+ API on Android API ≤26
+
+## How workers update this file
+
+1. Set ticket to `in_progress` when starting.
+2. On partial progress: leave `in_progress`, append note under ticket in `docs/PROGRESS.md`.
+3. On finish: set `done`, link PR/commit in PROGRESS.
+4. Never reorder priority without an explicit user request; append new tickets at end of the right phase.

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -9,7 +9,7 @@ Update this file when picking or finishing work. Cron workers must pick the **hi
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
 | F-001 | done | Environment bootstrap: JDK + Android SDK tooling on worker host | OpenJDK 17 + cmdline-tools; see `docs/ENV.md`, `scripts/env-mac.sh`. plugins/app/includer/depgen build green on host |
-| F-002 | todo | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
+| F-002 | done | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
 | F-003 | todo | Get plugins + sample `application/` building on modern toolchain | Host already green with current AGP 8.1.2 / Gradle 8.3–8.4; ticket may shrink to CI/modernization only |
 | F-004 | todo | CI green on GitHub Actions for plugins + application | Fix `.github/workflows` |
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,344 @@
+# Forma architecture audit
+
+Living map of the monorepo build graph, plugin modules, sample app, CI, and
+what should become **forma-core**. Source of truth for F-002; update when the
+graph changes.
+
+Last audited: **2026-07-11** (worker host green after F-001).
+
+---
+
+## 1. Repository layout (composite builds)
+
+The root `settings.gradle.kts` only names the project (`forma`); it is **not** a
+unified multi-project build. Real work lives in **independent Gradle builds**
+that compose via `includeBuild`:
+
+| Path | Role | Gradle wrapper | Publishes / consumed as |
+|------|------|----------------|-------------------------|
+| `plugins/` | Forma Gradle plugins (main product) | 8.3 | Composite + Plugin Portal (`tools.forma.*`) |
+| `application/` | Sample Android product (gold standard) | 8.4 | Consumer only |
+| `includer/` | Settings plugin: auto-`include` subprojects | (own wrapper) | `tools.forma.includer` |
+| `depgen/` | Transitive-deps generation plugin | (own wrapper) | `tools.forma.depgen` (standalone) |
+| `build-settings/` | Shared settings conventions (repos) | — | `includeBuild` / convention plugins |
+| `build-dependencies/` | Typed external dep catalogs for sample | — | `includeBuild` as `tools.forma.demo:dependencies` |
+| `docs/`, `scripts/` | Worker/env docs (not Gradle) | — | — |
+| `.github/workflows/` | CI | — | — |
+
+```
+                    ┌──────────────────────┐
+                    │   build-settings     │  convention-dependencies,
+                    │   (pluginManagement) │  convention-plugins (repos)
+                    └──────────┬───────────┘
+           includeBuild        │
+    ┌──────────────────────────┼──────────────────────────┐
+    │                          │                          │
+    v                          v                          v
+┌─────────┐   includeBuild  ┌────────────┐   includeBuild  ┌──────────────┐
+│includer │◄────────────────│ application│────────────────►│   plugins    │
+└─────────┘                 │  (sample)  │                 │  (product)   │
+                            └─────┬──────┘                 └──────┬───────┘
+                                  │ includeBuild                  │ includeBuild
+                                  v                               │ ../build-settings
+                         ┌─────────────────┐                      │
+                         │build-dependencies│                     │
+                         └─────────────────┘                      │
+                                                                  │
+┌─────────┐                                                       │
+│ depgen  │  (separate; not on application critical path)         │
+└─────────┘                                                       │
+```
+
+**Application `pluginManagement` / plugins** (from `application/settings.gradle.kts`):
+
+- `includeBuild("../build-settings")`, `../plugins`, `../includer`
+- Settings plugins: `convention-dependencies`, `tools.forma.includer`, `tools.forma.android`, Gradle Enterprise
+- `includeBuild("../build-dependencies")` for demo catalog
+- Heavy `buildscript` resolution forces (AGP 8.1.2, bundletool, asm, guava, …)
+
+**Plugins build** (`plugins/settings.gradle.kts`):
+
+- `pluginManagement { includeBuild("../build-settings") }`
+- `tools.forma.includer` **0.2.0** from Portal (not local includer composite)
+- Includer discovers `:android`, `:config`, `:deps`, `:owners`, `:target`, `:validation`
+
+---
+
+## 2. `plugins/` module graph
+
+Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
+
+```
+                    ┌────────────┐
+                    │   target   │  TargetTemplate, FormaTarget
+                    └─────▲──────┘
+                          │
+              ┌───────────┼────────────┐
+              │           │            │
+        ┌─────┴─────┐ ┌───┴────┐       │
+        │validation │ │ owners │       │
+        └─────▲─────┘ └───▲────┘       │
+              │           │            │
+        ┌─────┴─────┐     │      ┌─────┴─────┐
+        │   deps    │◄────┼──────┤  config   │
+        └─────▲─────┘     │      └─────▲─────┘
+              │           │            │
+              └─────┬─────┴────────────┘
+                    │
+              ┌─────┴─────┐
+              │  android  │  user-facing DSL + AGP features
+              └───────────┘
+```
+
+| Module | Plugin id | Depends on | Responsibility |
+|--------|-----------|------------|----------------|
+| `:target` | `tools.forma.target` | `gradleApi` | `TargetTemplate(suffix)`, `FormaTarget(project)` |
+| `:validation` | `tools.forma.validation` | `:target`, `gradleApi` | Name validators, content validators, `ProjectValidationError` |
+| `:owners` | `tools.forma.owners` | `gradleApi` | `Owner` / `Person` / `Team` / `NoOwner` |
+| `:config` | `tools.forma.config` | `gradleApi` | `AndroidProjectSettings`, `FormaSettingsStore`, plugin/dep registration maps |
+| `:deps` | `tools.forma.deps` | `:validation`, `:target`, `:config`, kotlin-dsl | `FormaDependency` model, `applyDependencies`, version-catalog generators |
+| `:android` | `tools.forma.android` | all of the above + **AGP** + Kotlin GP | Target DSL (`api`, `impl`, `androidLibrary`, …), feature appliers |
+
+`:android` `implementation("com.android.tools.build:gradle:7.4.2")` while the sample
+forces **AGP 8.1.2** at runtime — intentional skew to watch for F-003/F-004.
+
+`publishPlugins` on `:android` depends on publishing all sibling plugins.
+
+### 2.1 Target templates (suffixes)
+
+Defined in `plugins/android/.../AndroidTargets.kt`:
+
+| Object | Suffix | User DSL entrypoint |
+|--------|--------|---------------------|
+| `BinaryTargetTemplate` | `binary` | `androidBinary` |
+| `ApplicationTargetTemplate` | `app` | `androidApp` |
+| `LibraryTargetTemplate` | `library` | `androidLibrary` **and** `library` (JVM) |
+| `UiLibraryTargetTemplate` | `ui-library` | `uiLibrary` |
+| `NativeTarget` | `native` | `androidNative` |
+| `UtilTargetTemplate` | `util` | `util` |
+| `TestUtilTargetTemplate` | `test-util` | `testUtil` |
+| `AndroidTestUtilTargetTemplate` | `android-test-util` | `androidTestUtil` |
+| `AndroidUtilTargetTemplate` | `android-util` | `androidUtil` |
+| `ViewBindingTargetTemplate` | `viewbinding` | `viewBinding` |
+| `ResourcesTargetTemplate` | `res` | `androidRes` |
+| `ApiTargetTemplate` | `api` | `api` |
+| `ImplTargetTemplate` | `impl` | `impl` |
+| `WidgetTargetTemplate` | `widget` | `widget` |
+
+Name rule (`validation`): project name equals `suffix` or ends with `-$suffix`.
+
+### 2.2 Allowed project dependencies (from live validators)
+
+This is **code truth** (each target’s `applyDependencies(validator = …)`).
+README matrix (F-010) should be reconciled against this table — they diverge
+(e.g. several Android entry targets use `EmptyValidator`).
+
+| Consumer DSL | Allowed *project* dependency suffixes | Content rules |
+|--------------|----------------------------------------|---------------|
+| `api` | `api`, `library` | no `res/` under `src/main` |
+| `impl` | `api`, `android-util`, `test-util`, `util`, `library`, `ui-library`, `res`, `viewbinding`, `widget` | — |
+| `library` (JVM) | `util`, `test-util` | — |
+| `androidLibrary` | **EmptyValidator** (any project) | — |
+| `uiLibrary` | `widget`, `util`, `android-util`, `res` | — |
+| `util` | `util`, `library` | no `res/` |
+| `androidUtil` | `android-util`, `test-util`, `res` | no `res/` |
+| `testUtil` | `test-util`, `util` | no `res/` |
+| `androidTestUtil` | `android-test-util`, `test-util` | — |
+| `androidRes` | `res`, `widget` | **only** `res/` under `src/main` |
+| `widget` | `ui-library`, `widget`, `util`, `android-util`, `res` | — |
+| `viewBinding` | `api`, `widget`, `res`, `library`, `android-util` | only `layout*` under `src/main/res` |
+| `androidApp` | **EmptyValidator** | no `res/` |
+| `androidBinary` | **EmptyValidator** | no `res/` |
+| `androidNative` | (no `applyDependencies` in current code) | no `res/` |
+
+Notes for later tickets:
+
+- `impl` cannot depend on other `impl` (good for Dagger-ish boundaries) — F-011.
+- `androidLibrary` / `androidApp` / `androidBinary` skip dep-type checks — partial validation in README sense.
+- JVM `library` and Android `androidLibrary` share `LibraryTargetTemplate` suffix `library` — naming collision risk for forma-core registry design (F-020).
+
+### 2.3 Feature stack (Android module)
+
+Under `tools.forma.android.feature`:
+
+- `FeatureDefinition` + `applyFeatures`
+- `androidLibraryFeatureDefinition` / `androidBinaryFeatureDefinition` / `androidNativeDefinition`
+- Kotlin JVM vs Kotlin Android feature definitions
+- `kaptConfigurationFeature` (auto when kapt-ish deps present)
+
+Configuration singleton: `Forma` object delegates to `FormaSettingsStore`
+(`AndroidProjectSettings`: min/target/compile SDK, AGP/Kotlin versions, repos,
+compose flag, owners mandatory flag, Java compatibility).
+
+### 2.4 Deps subsystem
+
+- Model: `FormaDependency` sealed hierarchy (`NamedDependency`, `TargetDependency`,
+  `FileDependency`, `PlatformDependency`, `MixedDependency`, `EmptyDependency`)
+- Application: `applyDependencies` — validates each project dep, applies plugin
+  side-effects from catalog registrations, sets transitive flags
+- Catalog: `projectDependencies` / `bundle` / `plugin` in settings
+  (`tools.forma.deps.catalog`) + name generators
+- Sample also uses hand-written catalogs in `build-dependencies/dependencies`
+  (`Androidx`, `Google`, `Test`, …)
+
+### 2.5 Includer
+
+Settings plugin walks the tree for `build.gradle(.kts)` (optional arbitrary
+script names), skips nested settings roots, maps path → project name with
+`:` + path using `-` instead of `/` (avoids intermediate empty projects).
+Sample enables `arbitraryBuildScriptNames = true`.
+
+---
+
+## 3. Sample `application/` structure
+
+~35 Forma targets, multi-feature Rick-and-Morty style demo.
+
+```
+application/
+├── binary/                 androidBinary  (APK entry)
+├── root-app/               androidApp
+├── root-res/               androidRes
+├── toggle-widget/          widget
+├── core/
+│   ├── di/library          library
+│   ├── mvvm/library        library
+│   ├── navigation/library  library
+│   ├── network/library     library
+│   └── theme/{android-util,res}
+├── common/
+│   ├── util                util
+│   ├── extensions/{util,android-util}
+│   ├── placeholder/res
+│   ├── progressbar/{res,viewbinding}
+│   └── recyclerview/widget
+└── feature/
+    ├── home/{api,impl,res,viewbinding}
+    └── characters/
+        ├── core/{api,impl}
+        ├── list/{api,impl,res,viewbinding}
+        ├── detail/{api,impl,res,viewbinding}
+        └── favorite/{api,impl,res,viewbinding}
+```
+
+Wiring pattern:
+
+- Feature **api** = JVM Kotlin contracts (+ network/library etc.)
+- Feature **impl** = Android library + Dagger + navigation + viewbinding/res/widget
+- **binary** depends on root-app + all feature api/impl + shared core (explicit
+  graph; not only transitive)
+
+Root configuration (`application/build.gradle.kts`):
+
+```kotlin
+androidProjectConfiguration(
+  minSdk = 21, targetSdk = 33, compileSdk = 33,
+  agpVersion = "8.1.2",
+  extraPlugins = [ demo deps, KSP, nav safe-args, crashlytics ]
+)
+```
+
+---
+
+## 4. CI (`.github/workflows/main.yml`)
+
+Workflow name: **Run build checks** (`on: push`, `workflow_dispatch`).
+
+| Job | Directory | Java setup | Notes |
+|-----|-----------|------------|-------|
+| `build_application` | `application/` | Temurin **17** | `./gradlew build -s --console=plain --scan` |
+| `build_plugins` | `plugins/` | **none explicit** | relies on runner default |
+| `build_includer` | `includer/` | **none explicit** | |
+| `build_depgen` | `depgen/` | **none explicit** | |
+
+Gaps for F-004:
+
+1. Non-application jobs should pin Java 17 (parity with F-001 host).
+2. No Android SDK setup step for `build_application` (needs cmdline-tools /
+   `ANDROID_HOME` / licenses — likely flaky or image-dependent).
+3. README badge still points at old `stepango/forma` “Android CI” workflow name;
+   this repo uses `formatools/forma` + “Run build checks”.
+4. No cache strategy beyond `gradle/gradle-build-action@v2` (action itself caches).
+5. Plugins job does not publish or run Plugin Marker validation.
+
+---
+
+## 5. Toolchain snapshot (host + declared)
+
+| Component | Declared / observed |
+|-----------|---------------------|
+| JDK | 17 (CI application job; host OpenJDK 17 via Homebrew) |
+| Gradle | plugins 8.3, application 8.4 |
+| AGP | sample 8.1.2 (forced); plugins compile against 7.4.2 |
+| Kotlin | embeddedKotlin from Gradle distribution |
+| Android SDK | sample compile/target 33; host platforms;android-33 + build-tools 33/34 |
+| Forma version | 0.1.3 |
+
+Host bootstrap details: `docs/ENV.md`, `scripts/env-mac.sh` (F-001).
+
+---
+
+## 6. forma-core extraction map (candidates)
+
+Aligned with `docs/VISION.md`: core must not assume Android/AGP/Dagger.
+
+| Concern | Current home | forma-core? | Notes |
+|---------|--------------|-------------|-------|
+| Target type identity (`TargetTemplate` / suffix) | `:target` | **Yes** | Registry API (F-020/F-021) |
+| Name + dep-type `Validator` | `:validation` | **Yes** | Keep framework; Android content rules as plugins |
+| Content validators (`onlyAllowResources`, …) | `:android` + `:validation` helpers | **Split** | Generic dir checks → core; Android paths → android plugin |
+| Dependency model + apply | `:deps` | **Mostly yes** | Strip AGP-ish config features; catalog generators may stay tooling |
+| Settings store | `:config` | **Split** | Generic `SettingsStore` / plugin registry → core; `AndroidProjectSettings` → android |
+| Owners | `:owners` | **Optional / yes** | Platform-agnostic metadata |
+| Feature definitions (AGP library/binary/native) | `:android` | **No** | Stay platform |
+| DSL entrypoints (`api`/`impl`/…) | `:android` | **No** (register *onto* core) | First consumer of core (F-023) |
+| Includer / depgen | separate builds | **No** | Adjacent tooling |
+| build-dependencies catalogs | sample support | **No** | Demo-only; pattern informs F-012 |
+
+Suggested extraction order (tickets F-020…F-024):
+
+1. Document public API (`docs/forma-core-api.md`) — types, restriction engine, validator SPI, target registry.
+2. Move `:target` + pure validation + restriction tables into `forma-core`.
+3. Re-home `applyDependencies` project-validation path on core validators.
+4. Leave `:android` as the first platform package implementing templates + AGP features.
+5. Coordinates: e.g. `tools.forma:core` vs `tools.forma.android` (F-024).
+
+---
+
+## 7. Known inconsistencies / follow-ups
+
+| Item | Ticket |
+|------|--------|
+| README dependency matrix ≠ live validators | F-010 |
+| `EmptyValidator` on app/binary/androidLibrary | F-011 |
+| AGP 7.4.2 compile vs 8.1.2 runtime | F-003 |
+| CI missing SDK + Java on some jobs | F-004 |
+| Compose flag in settings, limited target support | F-013 |
+| Shared `library` suffix for JVM vs Android library | F-020 |
+| Plugin publish / Portal path | F-016 |
+| Configuration-time cost (includer walk, stores) | F-017 |
+
+---
+
+## 8. Quick reference — where to change what
+
+| Goal | Start here |
+|------|------------|
+| New target type | `AndroidTargets.kt` + new DSL file under `plugins/android/src/main/java/` + validator list |
+| Tighten dep rules | `validator(...)` in that DSL file; update this doc §2.2 |
+| Global SDK/AGP defaults | `androidProjectConfiguration` + sample `application/build.gradle.kts` |
+| External deps UX | `plugins/deps` catalog + `build-dependencies` |
+| Auto module discovery | `includer/` |
+| CI | `.github/workflows/main.yml` |
+| Sample structure | `application/feature/**`, `binary/` |
+
+---
+
+## 9. Audit method
+
+- Walked all `settings.gradle.kts` / `build.gradle.kts` for composite edges.
+- Read every `plugins/android` DSL entrypoint for `validator(...)` and content checks.
+- Listed `application/**/build.gradle.kts` targets and feature folders.
+- Inspected `.github/workflows/main.yml` and wrapper properties.
+- Host builds (F-001): `plugins/`, `includer/`, `depgen/`, `application/` all
+  **BUILD SUCCESSFUL** on OpenJDK 17 + Android SDK 33 — not re-run in this audit slice.

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -1,0 +1,75 @@
+# Worker host environment (macOS)
+
+Forma workers need **JDK 17+** and an **Android SDK** with platform 33 (sample app `compileSdk`/`targetSdk`).
+
+## Quick start (this Mac)
+
+```bash
+# Already installed on the Forma worker host (no sudo):
+#   brew install openjdk@17
+#   brew install --cask android-commandlinetools
+#   sdk packages: platforms;android-33, platform-tools, build-tools 33.0.2 + 34.0.0
+
+source scripts/env-mac.sh
+
+# Point Gradle at the SDK (gitignored):
+printf 'sdk.dir=%s\n' "$ANDROID_HOME" > application/local.properties
+
+# Verify
+java -version
+cd plugins && ./gradlew build
+cd ../application && ./gradlew build
+cd ../includer && ./gradlew build
+cd ../depgen && ./gradlew build
+```
+
+## Paths used on this host
+
+| Tool | Location |
+|------|----------|
+| JDK 17 | `/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home` |
+| Android SDK root | `/usr/local/share/android-commandlinetools` |
+| cmdline-tools | `$ANDROID_HOME/cmdline-tools/latest` |
+
+`openjdk@17` is Homebrew **keg-only** (not on system `PATH` until you export `JAVA_HOME`). Prefer it over `brew install --cask temurin@17`, which requires **sudo** for the `.pkg` installer and fails in non-interactive cron.
+
+## One-time install (fresh machine)
+
+```bash
+brew install openjdk@17
+brew install --cask android-commandlinetools
+
+export JAVA_HOME="/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"
+export ANDROID_HOME="/usr/local/share/android-commandlinetools"
+export ANDROID_SDK_ROOT="$ANDROID_HOME"
+export PATH="$JAVA_HOME/bin:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
+
+yes | sdkmanager --licenses
+sdkmanager --install \
+  "platforms;android-33" \
+  "platform-tools" \
+  "build-tools;33.0.2" \
+  "build-tools;34.0.0"
+
+printf 'sdk.dir=%s\n' "$ANDROID_HOME" > application/local.properties
+```
+
+Optional system-wide JVM registration (needs sudo, not required for Gradle):
+
+```bash
+sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk \
+  /Library/Java/JavaVirtualMachines/openjdk-17.jdk
+```
+
+## Verified on 2026-07-10 (F-001)
+
+- `java` / `javac` 17.0.19 (Homebrew OpenJDK)
+- `plugins/`: `./gradlew build` → **BUILD SUCCESSFUL**
+- `includer/`: `./gradlew build` → **BUILD SUCCESSFUL**
+- `depgen/`: `./gradlew build` → **BUILD SUCCESSFUL**
+- `application/`: `./gradlew build` → **BUILD SUCCESSFUL** (2080 tasks, with Android SDK 33)
+- Gradle wrappers: plugins 8.3, application 8.4
+
+## Shell profile
+
+`~/.zshrc` on the worker exports `JAVA_HOME` / `ANDROID_HOME` so interactive shells pick them up. Cron / Hermes sessions should still `source scripts/env-mac.sh` (or set the same vars) because non-interactive jobs may not load `.zshrc`.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,22 @@
 
 Newest entries first.
 
+## 2026-07-11 — F-002 Architecture audit (build graph)
+
+- **Ticket:** F-002 → `done`
+- **Branch:** `forma/F-002-architecture-audit` (stacked on F-001 docs commit)
+- **Actions:**
+  - Mapped composite builds: `plugins/`, `application/`, `includer/`, `depgen/`, `build-settings/`, `build-dependencies/`
+  - Documented plugins module DAG (`target` → `validation`/`owners`/`config` → `deps` → `android`)
+  - Extracted **live** allowed-dependency validators from every Android DSL entrypoint into a table (code truth vs README matrix)
+  - Listed sample app ~35 targets (feature api/impl/res/viewbinding pattern)
+  - Audited CI workflow gaps (Java only on application job; no Android SDK step; badge/name drift)
+  - Marked forma-core extraction candidates vs Android-only code
+- **Artifact:** `docs/ARCHITECTURE.md`
+- **Commits/PRs:** this run — push + PR
+- **Blockers:** none (docs-only slice; builds not re-run; F-001 host green still the baseline)
+- **Next step:** F-003 (toolchain modernization / AGP compile vs runtime skew) or F-004 (CI green) — prefer F-003 only if code changes needed; CI is the remaining P0 risk
+
 ## 2026-07-10 — F-001 Environment bootstrap (JDK + Android SDK)
 
 - **Ticket:** F-001 → `done`

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -1,0 +1,34 @@
+# Forma progress log
+
+Newest entries first.
+
+## 2026-07-10 — F-001 Environment bootstrap (JDK + Android SDK)
+
+- **Ticket:** F-001 → `done`
+- **Branch:** `forma/F-001-jdk-bootstrap` (from `origin/master`)
+- **Host toolchain:**
+  - JDK: Homebrew `openjdk@17` 17.0.19 at `/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home` (keg-only; no sudo). `brew install --cask temurin@17` fails without interactive sudo.
+  - Android SDK: `brew install --cask android-commandlinetools` → `/usr/local/share/android-commandlinetools`; installed `platforms;android-33`, `platform-tools`, `build-tools;33.0.2` + `34.0.0`; licenses accepted.
+  - `application/local.properties` written (gitignored) with `sdk.dir`.
+  - `~/.zshrc` exports `JAVA_HOME` / `ANDROID_HOME` for interactive shells.
+- **Repo docs/scripts:**
+  - `docs/ENV.md` — install + verify steps
+  - `scripts/env-mac.sh` — sourceable env for cron/workers
+- **Build verification (real tool output):**
+  - `plugins/`: `./gradlew build` → **BUILD SUCCESSFUL** (58 tasks)
+  - `includer/`: `./gradlew build` → **BUILD SUCCESSFUL**
+  - `depgen/`: `./gradlew build` → **BUILD SUCCESSFUL**
+  - `application/`: `./gradlew build` → **BUILD SUCCESSFUL** in 3m29s (2080 tasks)
+- **Commits/PRs:** (this run) push + PR for env docs/scripts; host packages stay machine-local
+- **Blockers:** none for local Gradle; optional `sudo ln -sfn …/openjdk.jdk` into `/Library/Java/JavaVirtualMachines` not done (sudo password unavailable)
+- **Next step:** F-002 audit build graph → `docs/ARCHITECTURE.md`; F-003 may largely be closed by host green builds (confirm CI separately as F-004)
+
+## 2026-07-10 — Workspace init + cron online
+
+- Cloned `formatools/forma` → `/Users/claw/work/forma` (branch `forma/agent-workspace`)
+- Wrote `docs/VISION.md`, `TICKETS.md`, `AGENTS.md`, this log
+- Cron jobs:
+  - `18717ea2093c` **forma 4h ticket worker** — every 240m, workdir `/Users/claw/work/forma`, deliver `telegram:-1003754340081:136`, model `grok-4.5` / `custom:xai`, toolsets terminal+file+web
+  - `1c872230b69e` **forma daily progress report** — `0 10 * * *` (10:00 America/Los_Angeles), same deliver/workdir, toolsets terminal+file
+- Prompt sources: `docs/cron-worker-prompt.txt`, `docs/cron-daily-prompt.txt`
+- Host note: no Java runtime installed yet (blocks Gradle until F-001)

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -1,0 +1,41 @@
+# Forma Strategic Vision
+
+## Product goal
+
+Make **Forma** a working product for **Android** first, then adapt the same approach for **JVM applications**, then for **Bazel**.
+
+## Architectural split
+
+### `forma-core` (framework)
+
+The portable core for:
+
+- Building **dependency types** and **restriction / visibility rules**
+- Validation framework for project structure
+- Tooling / utils (e.g. external dependency catalogs, dependency application helpers)
+- Target-type registration API (pluggable implementations)
+
+`forma-core` must not assume Android, AGP, or Dagger. It is the substrate other platforms stand on.
+
+### Platform implementations (examples)
+
+Concrete stacks built **on** forma-core:
+
+1. **Android** — full target set (`api`, `impl`, `androidLibrary`, `androidBinary`, …) with strict dependency matrix based on the current Forma implementation; Dagger2-friendly `api`/`impl` conventions; external deps catalog patterns.
+2. **JVM** — pure JVM targets and samples reusing the same restriction model.
+3. **Bazel** — later adapter that reuses forma-core concepts (types + restrictions) rather than forking the rules engine.
+
+## Sequencing
+
+1. **Android productization** — modern toolchain, green CI/sample, strict types, publishable plugin.
+2. **Extract forma-core** — peel framework concerns out of the Android plugin while Android keeps working.
+3. **JVM implementation** — prove core is portable.
+4. **Bazel** — design + implement adapter once core is stable.
+
+## Working principles
+
+- Prefer small, reviewable PRs against `formatools/forma` (fork/PR flow as needed).
+- Keep the sample `application/` building as the product gold standard.
+- Document user-facing changes in `README.md`.
+- Track work only via `TICKETS.md` + `docs/PROGRESS.md` (and GitHub issues/PRs).
+- Do not invent unrelated features; stay on the prioritized ticket list.

--- a/docs/cron-daily-prompt.txt
+++ b/docs/cron-daily-prompt.txt
@@ -1,0 +1,22 @@
+You are the Forma daily progress reporter.
+
+## Mission
+Produce a grounded daily progress report for the Forma productization effort (Android → forma-core → JVM → Bazel). Workdir: /Users/claw/work/forma. Follow AGENTS.md.
+
+## Each run
+1. Read TICKETS.md and docs/PROGRESS.md (full recent history).
+2. Inspect git: branch, log --since=yesterday, status; list open PRs: `gh pr list --repo formatools/forma --state open` (and any fork remotes if present).
+3. Inspect 4h worker activity: `ls -lt ~/.hermes/cron/output/ | head -20` and open the newest forma worker outputs if present.
+4. Optionally: attempt a quick toolchain sanity check (`java -version`, `./gradlew -v` in plugins/ if Java exists). Report failures honestly.
+5. Write a short scannable report covering:
+   - Tickets moved (done / in_progress / blocked)
+   - Commits and open PRs in the last ~24–48h
+   - Build/CI status if known
+   - Blockers and recommended next actions
+6. Append a one-line pointer into docs/PROGRESS.md only if new facts were discovered beyond the 4h worker notes (optional).
+7. Final response = the full daily report for Telegram delivery. Do NOT use send_message. If genuinely nothing changed and no open work/blockers, output exactly [SILENT].
+
+## Constraints
+- Ground every claim in tool output. No speculation.
+- Do not implement product code in this job (reporting only).
+- Do not create or edit cron jobs.

--- a/docs/cron-worker-prompt.txt
+++ b/docs/cron-worker-prompt.txt
@@ -1,0 +1,24 @@
+You are the Forma 4h autonomous ticket worker.
+
+## Mission
+Make formatools/forma a working Android product, then extract forma-core (dependency types/restrictions + tooling), then JVM, then Bazel. Full strategic vision is in docs/VISION.md. Work ONLY through the prioritized list in TICKETS.md.
+
+## Workdir
+Always operate in /Users/claw/work/forma. Follow AGENTS.md strictly.
+
+## Each run (do all of this)
+1. Read AGENTS.md, docs/VISION.md, TICKETS.md, and the latest entries in docs/PROGRESS.md.
+2. git status / git branch / git log -5. Prefer continuing forma/* branches; otherwise branch from origin/master as forma/F-XXX-slug.
+3. Select the highest-priority ticket with status todo or in_progress (never reorder priorities).
+4. Execute a meaningful slice for that ticket (code, build fixes, docs, toolchain). Prefer shippable PR-sized work over sprawling rewrites.
+5. Update TICKETS.md status and append a dated section to docs/PROGRESS.md (ticket id, what changed, commits/PRs, blockers, next step).
+6. Commit workspace/docs + code changes with message "F-XXX: concise summary". Open a GitHub PR when the slice is coherent (gh pr create against formatools/forma or your fork if needed).
+7. Final response = concise human report: ticket worked, progress, PR links, blockers. The scheduler delivers it — do NOT use send_message.
+
+## Constraints
+- No Java today may block Gradle: if so, prioritize F-001 (install Temurin 17+ / document SDK needs) before pretending builds pass.
+- Never invent green builds — ground claims in command output.
+- Do not create/modify other cron jobs.
+- Do not force-push master on upstream.
+- Stay on Forma; ignore grkr/personal tasks.
+- Keep files ≤ ~1000 lines when practical.

--- a/scripts/env-mac.sh
+++ b/scripts/env-mac.sh
@@ -1,0 +1,30 @@
+#!/usr/bin/env bash
+# Source this on the Forma worker Mac before Gradle:
+#   source scripts/env-mac.sh
+#
+# Install (one-time, no sudo required for these paths):
+#   brew install openjdk@17
+#   brew install --cask android-commandlinetools
+#   export JAVA_HOME="/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home"
+#   export ANDROID_HOME="/usr/local/share/android-commandlinetools"
+#   yes | "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --licenses
+#   "$ANDROID_HOME/cmdline-tools/latest/bin/sdkmanager" --install \
+#     "platforms;android-33" "platform-tools" "build-tools;33.0.2" "build-tools;34.0.0"
+#   printf 'sdk.dir=%s\n' "$ANDROID_HOME" > application/local.properties
+#
+# Note: brew install --cask temurin@17 needs sudo for the system pkg installer;
+# openjdk@17 (formula) is keg-only and does not need sudo.
+
+export JAVA_HOME="${JAVA_HOME:-/usr/local/opt/openjdk@17/libexec/openjdk.jdk/Contents/Home}"
+export ANDROID_HOME="${ANDROID_HOME:-/usr/local/share/android-commandlinetools}"
+export ANDROID_SDK_ROOT="${ANDROID_SDK_ROOT:-$ANDROID_HOME}"
+export PATH="$JAVA_HOME/bin:$ANDROID_HOME/cmdline-tools/latest/bin:$ANDROID_HOME/platform-tools:$PATH"
+
+if [[ ! -x "$JAVA_HOME/bin/java" ]]; then
+  echo "env-mac.sh: java not found at $JAVA_HOME/bin/java" >&2
+  return 1 2>/dev/null || exit 1
+fi
+
+if [[ ! -d "$ANDROID_HOME/platforms/android-33" ]]; then
+  echo "env-mac.sh: warning: Android platform 33 missing under $ANDROID_HOME" >&2
+fi


### PR DESCRIPTION
## Summary
- Audit monorepo composite builds, plugins module DAG, sample app targets, and CI.
- Capture live dependency validators (code truth) vs README matrix gaps.
- Map forma-core extraction candidates for F-020+.

## Ticket
F-002 → done. Stacked on F-001 env docs commit.

## Test plan
- [x] Docs-only change; no code paths modified
- [ ] Skim `docs/ARCHITECTURE.md` for accuracy against `plugins/android` DSL
- [ ] Confirm next worker picks F-003 or F-004 from TICKETS.md