### PR TITLE
F-003: align plugins AGP compile dep with sample 8.1.2

### DIFF
--- a/README.md
+++ b/README.md
@@ -60,10 +60,10 @@ buildscript {
         minSdk = 21,
         targetSdk = 33,
         compileSdk = 33,
-        agpVersion = "7.4.2",
+        agpVersion = "8.1.2",
         extraPlugins = listOf(
-            "androidx.navigation:navigation-safe-args-gradle-plugin:2.5.3",
-            "com.google.firebase:firebase-crashlytics-gradle:2.9.4",
+            "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.4",
+            "com.google.firebase:firebase-crashlytics-gradle:2.9.9",
         )
     )
 }

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -10,7 +10,7 @@ Update this file when picking or finishing work. Cron workers must pick the **hi
 |----|--------|-------|-------|
 | F-001 | done | Environment bootstrap: JDK + Android SDK tooling on worker host | OpenJDK 17 + cmdline-tools; see `docs/ENV.md`, `scripts/env-mac.sh`. plugins/app/includer/depgen build green on host |
 | F-002 | done | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
-| F-003 | todo | Get plugins + sample `application/` building on modern toolchain | Host already green with current AGP 8.1.2 / Gradle 8.3–8.4; ticket may shrink to CI/modernization only |
+| F-003 | done | Get plugins + sample `application/` building on modern toolchain | Plugins compile AGP 8.1.2 matches sample; Gradle 8.3 (plugins) / 8.4 (app); host builds green |
 | F-004 | todo | CI green on GitHub Actions for plugins + application | Fix `.github/workflows` |
 
 ## P1 — Android working product

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -99,8 +99,9 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
 | `:deps` | `tools.forma.deps` | `:validation`, `:target`, `:config`, kotlin-dsl | `FormaDependency` model, `applyDependencies`, version-catalog generators |
 | `:android` | `tools.forma.android` | all of the above + **AGP** + Kotlin GP | Target DSL (`api`, `impl`, `androidLibrary`, …), feature appliers |
 
-`:android` `implementation("com.android.tools.build:gradle:7.4.2")` while the sample
-forces **AGP 8.1.2** at runtime — intentional skew to watch for F-003/F-004.
+`:android` compiles against **AGP 8.1.2** (aligned with sample runtime force in
+`application/settings.gradle.kts` as of F-003). Keep `plugins/android` AGP
+compile dep and consumer `agpVersion` in lockstep.
 
 `publishPlugins` on `:android` depends on publishing all sibling plugins.
 
@@ -269,7 +270,7 @@ Gaps for F-004:
 |-----------|---------------------|
 | JDK | 17 (CI application job; host OpenJDK 17 via Homebrew) |
 | Gradle | plugins 8.3, application 8.4 |
-| AGP | sample 8.1.2 (forced); plugins compile against 7.4.2 |
+| AGP | **8.1.2** sample runtime + plugins compile (aligned F-003) |
 | Kotlin | embeddedKotlin from Gradle distribution |
 | Android SDK | sample compile/target 33; host platforms;android-33 + build-tools 33/34 |
 | Forma version | 0.1.3 |
@@ -311,7 +312,7 @@ Suggested extraction order (tickets F-020…F-024):
 |------|--------|
 | README dependency matrix ≠ live validators | F-010 |
 | `EmptyValidator` on app/binary/androidLibrary | F-011 |
-| AGP 7.4.2 compile vs 8.1.2 runtime | F-003 |
+| ~~AGP 7.4.2 compile vs 8.1.2 runtime~~ (aligned 8.1.2) | F-003 done |
 | CI missing SDK + Java on some jobs | F-004 |
 | Compose flag in settings, limited target support | F-013 |
 | Shared `library` suffix for JVM vs Android library | F-020 |

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -61,14 +61,15 @@ sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk \
   /Library/Java/JavaVirtualMachines/openjdk-17.jdk
 ```
 
-## Verified on 2026-07-10 (F-001)
+## Verified on 2026-07-10 (F-001) / re-verified 2026-07-11 (F-003)
 
 - `java` / `javac` 17.0.19 (Homebrew OpenJDK)
-- `plugins/`: `./gradlew build` → **BUILD SUCCESSFUL**
+- `plugins/`: `./gradlew build` → **BUILD SUCCESSFUL** (AGP compile dep **8.1.2**)
 - `includer/`: `./gradlew build` → **BUILD SUCCESSFUL**
 - `depgen/`: `./gradlew build` → **BUILD SUCCESSFUL**
-- `application/`: `./gradlew build` → **BUILD SUCCESSFUL** (2080 tasks, with Android SDK 33)
+- `application/`: `./gradlew build` → **BUILD SUCCESSFUL** (2080 tasks, AGP runtime 8.1.2, Android SDK 33)
 - Gradle wrappers: plugins 8.3, application 8.4
+- Toolchain note: plugins compile AGP matches sample forced AGP (no 7.4.2 skew)
 
 ## Shell profile
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,22 @@
 
 Newest entries first.
 
+## 2026-07-11 — F-003 Modern toolchain (AGP compile/runtime align)
+
+- **Ticket:** F-003 → `done`
+- **Branch:** `forma/F-003-modern-toolchain` (from `origin/v2`)
+- **Actions:**
+  - Bumped `plugins/android` compile dep `com.android.tools.build:gradle` **7.4.2 → 8.1.2** to match sample runtime force (`application/settings.gradle.kts` + `agpVersion = "8.1.2"`)
+  - README sample config: `agpVersion` + nav safe-args / crashlytics plugin versions aligned with application
+  - Docs: `ARCHITECTURE.md` toolchain snapshot + inconsistency table; `ENV.md` re-verify notes; `TICKETS.md` status
+- **Build verification (real tool output, OpenJDK 17 + SDK 33):**
+  - `plugins/`: `./gradlew build` → **BUILD SUCCESSFUL** in 42s (58 tasks; `:android:compileKotlin` clean after AGP bump)
+  - `application/`: `./gradlew build` → **BUILD SUCCESSFUL** in 3m8s (2080 tasks)
+- **Not in this slice:** CI workflow (F-004 — still missing Java on plugin jobs + Android SDK setup); further AGP/Gradle bumps beyond 8.1.2/8.4
+- **Commits/PRs:** this run — push + PR base `v2`
+- **Blockers:** none for local modern-toolchain claim
+- **Next step:** F-004 CI green (pin Temurin 17 on all jobs; install Android SDK for `build_application`; fix badge/name drift)
+
 ## 2026-07-11 — v2 base of operations (merge open PRs)
 
 - **Action:** Created integration branch `v2` from `origin/master`, merged open work from:

--- a/plugins/android/build.gradle.kts
+++ b/plugins/android/build.gradle.kts
@@ -32,7 +32,9 @@ tasks.named("compileKotlin", KotlinCompilationTask::class.java) {
 }
 
 dependencies {
-    implementation("com.android.tools.build:gradle:7.4.2")
+    // Compile against the same AGP line the sample forces at runtime (see application/settings.gradle.kts).
+    // Keep this in lockstep with androidProjectConfiguration(agpVersion=…) consumers (F-003).
+    implementation("com.android.tools.build:gradle:8.1.2")
     implementation(embeddedKotlin("gradle-plugin"))
     implementation(project(":target"))
     implementation(project(":validation"))


### PR DESCRIPTION
## Summary
- Bump `plugins/android` compile dependency `com.android.tools.build:gradle` from **7.4.2 → 8.1.2** so plugin compilation matches the sample app runtime force (`application/settings.gradle.kts` / `agpVersion = "8.1.2"`).
- Align README getting-started snippet (AGP + nav safe-args + crashlytics versions) with the sample.
- Update `docs/ARCHITECTURE.md`, `docs/ENV.md`, `TICKETS.md`, `docs/PROGRESS.md`.

## Verification (worker host, OpenJDK 17 + Android SDK 33)
- `plugins/`: `./gradlew build` → **BUILD SUCCESSFUL** (42s, 58 tasks)
- `application/`: `./gradlew build` → **BUILD SUCCESSFUL** (3m8s, 2080 tasks)

## Out of scope
- CI workflow fixes → **F-004**
- Further AGP/Gradle bumps past 8.1.2 / 8.4

## Ticket
F-003 → done