### PR TITLE
F-004: pin JDK 17 + Android SDK in GitHub Actions CI

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -1,56 +1,86 @@
-name: Run build checks
+# Forma CI — plugins, sample app, and adjacent tooling.
+# F-004: pin JDK 17 on every job; install Android SDK for the sample app.
+name: CI
 
-on: [ push, workflow_dispatch ]
+on:
+  push:
+  pull_request:
+  workflow_dispatch:
+
+concurrency:
+  group: ci-${{ github.workflow }}-${{ github.ref }}
+  cancel-in-progress: true
 
 jobs:
-  build_application:
-
+  build_plugins:
+    name: Plugins
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-      - uses: actions/setup-java@v3
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
         with:
           distribution: temurin
-          java-version: 17
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        id: gradle-setup
-      - name: Build Application
-        run: (cd application || exit 1; ./gradlew build -s --console=plain --scan)
-
-  build_depgen:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        id: gradle-setup
-      - name: Build Depgen
-        run: (cd depgen || exit 1; ./gradlew build -s --console=plain)
-
-  build_plugins:
-
-    runs-on: ubuntu-latest
-
-    steps:
-      - uses: actions/checkout@v4
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        id: gradle-setup
-      - name: Build Plugins
-        run: (cd plugins || exit 1; ./gradlew build -s --console=plain)
+          java-version: "17"
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build plugins
+        working-directory: plugins
+        run: ./gradlew build --stacktrace --console=plain
 
   build_includer:
-
+    name: Includer
     runs-on: ubuntu-latest
-
     steps:
       - uses: actions/checkout@v4
-      - name: Setup Gradle
-        uses: gradle/gradle-build-action@v2
-        id: gradle-setup
-      - name: Build Includer
-        run: (cd includer || exit 1; ./gradlew build -s --console=plain)
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build includer
+        working-directory: includer
+        run: ./gradlew build --stacktrace --console=plain
+
+  build_depgen:
+    name: Depgen
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build depgen
+        working-directory: depgen
+        run: ./gradlew build --stacktrace --console=plain
+
+  build_application:
+    name: Application
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+      - name: Set up JDK 17
+        uses: actions/setup-java@v4
+        with:
+          distribution: temurin
+          java-version: "17"
+      # Sample app: compileSdk/targetSdk 33 (see application/build.gradle.kts).
+      # setup-android accepts licenses, installs cmdline-tools + listed packages,
+      # and exports ANDROID_HOME / ANDROID_SDK_ROOT for AGP.
+      - name: Set up Android SDK
+        uses: android-actions/setup-android@v3
+        with:
+          # Space-separated sdkmanager package ids (semicolons inside package names).
+          packages: "platform-tools platforms;android-33 build-tools;33.0.2 build-tools;34.0.0"
+      - name: Set up Gradle
+        uses: gradle/actions/setup-gradle@v4
+      - name: Build application
+        working-directory: application
+        # No --scan: avoids build-scan ToS prompts / account coupling in CI.
+        run: ./gradlew build --stacktrace --console=plain

--- a/README.md
+++ b/README.md
@@ -3,9 +3,9 @@
 </p>
 
 <p align="center">
-    <img src="https://github.com/stepango/forma/workflows/Android%20CI/badge.svg"/>
+    <img src="https://github.com/formatools/forma/actions/workflows/main.yml/badge.svg" alt="CI"/>
     <a href="https://plugins.gradle.org/plugin/tools.forma.android"><img src="https://img.shields.io/maven-metadata/v/https/plugins.gradle.org/m2/tools/forma/android/tools.forma.android.gradle.plugin/maven-metadata.xml.svg?colorB=007ec6&label=Gradle%20Plugin"/></a>
-    <img alt="GitHub code size in bytes" src="https://img.shields.io/github/languages/code-size/stepango/forma">
+    <img alt="GitHub code size in bytes" src="https://img.shields.io/github/languages/code-size/formatools/forma">
     <img alt="License" src="https://img.shields.io/github/license/formatools/forma"/>
     <img alt="Contributors" src="https://img.shields.io/github/contributors/formatools/forma"/>
     <img alt="GitHub top language" src="https://img.shields.io/github/languages/top/formatools/forma"/>

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -11,7 +11,7 @@ Update this file when picking or finishing work. Cron workers must pick the **hi
 | F-001 | done | Environment bootstrap: JDK + Android SDK tooling on worker host | OpenJDK 17 + cmdline-tools; see `docs/ENV.md`, `scripts/env-mac.sh`. plugins/app/includer/depgen build green on host |
 | F-002 | done | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
 | F-003 | todo | Get plugins + sample `application/` building on modern toolchain | Host already green with current AGP 8.1.2 / Gradle 8.3–8.4; ticket may shrink to CI/modernization only |
-| F-004 | todo | CI green on GitHub Actions for plugins + application | Fix `.github/workflows` |
+| F-004 | in_progress | CI green on GitHub Actions for plugins + application | Fix `.github/workflows` |
 
 ## P1 — Android working product
 

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -11,7 +11,7 @@ Update this file when picking or finishing work. Cron workers must pick the **hi
 | F-001 | done | Environment bootstrap: JDK + Android SDK tooling on worker host | OpenJDK 17 + cmdline-tools; see `docs/ENV.md`, `scripts/env-mac.sh`. plugins/app/includer/depgen build green on host |
 | F-002 | done | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
 | F-003 | todo | Get plugins + sample `application/` building on modern toolchain | Host already green with current AGP 8.1.2 / Gradle 8.3–8.4; ticket may shrink to CI/modernization only |
-| F-004 | in_progress | CI green on GitHub Actions for plugins + application | Fix `.github/workflows` |
+| F-004 | done | CI green on GitHub Actions for plugins + application | Temurin 17 all jobs + Android SDK 33 for app; PR #153 GHA green |
 
 ## P1 — Android working product
 

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -242,24 +242,26 @@ androidProjectConfiguration(
 
 ## 4. CI (`.github/workflows/main.yml`)
 
-Workflow name: **Run build checks** (`on: push`, `workflow_dispatch`).
+Display name **CI** (`on: push`, `pull_request`, `workflow_dispatch`).
 
-| Job | Directory | Java setup | Notes |
-|-----|-----------|------------|-------|
-| `build_application` | `application/` | Temurin **17** | `./gradlew build -s --console=plain --scan` |
-| `build_plugins` | `plugins/` | **none explicit** | relies on runner default |
-| `build_includer` | `includer/` | **none explicit** | |
-| `build_depgen` | `depgen/` | **none explicit** | |
+| Job | Directory | Java | Notes |
+|-----|-----------|------|-------|
+| `build_application` | `application/` | Temurin **17** | `android-actions/setup-android@v3` (SDK 33 + build-tools 33/34); `./gradlew build --stacktrace --console=plain` |
+| `build_plugins` | `plugins/` | Temurin **17** | `./gradlew build --stacktrace --console=plain` |
+| `build_includer` | `includer/` | Temurin **17** | same |
+| `build_depgen` | `depgen/` | Temurin **17** | same |
 
-Gaps for F-004:
+Concurrency group `ci-${{ github.workflow }}-${{ github.ref }}` cancels in-progress runs on the same ref.
 
-1. Non-application jobs should pin Java 17 (parity with F-001 host).
-2. No Android SDK setup step for `build_application` (needs cmdline-tools /
-   `ANDROID_HOME` / licenses — likely flaky or image-dependent).
-3. README badge still points at old `stepango/forma` “Android CI” workflow name;
-   this repo uses `formatools/forma` + “Run build checks”.
-4. No cache strategy beyond `gradle/gradle-build-action@v2` (action itself caches).
-5. Plugins job does not publish or run Plugin Marker validation.
+F-004 fixes applied (2026-07-11):
+
+1. **All jobs** pin Temurin 17 via `actions/setup-java@v4`.
+2. **Application** installs Android SDK packages matching sample `compileSdk` 33.
+3. README badge → `formatools/forma` + `actions/workflows/main.yml/badge.svg`.
+4. Gradle setup via `gradle/actions/setup-gradle@v4` (successor of `gradle-build-action`).
+5. Dropped unconditional `--scan` (no build-scan account coupling in CI).
+
+Still optional / later: plugin publish or Plugin Marker validation job; deeper Gradle remote cache.
 
 ---
 
@@ -267,7 +269,7 @@ Gaps for F-004:
 
 | Component | Declared / observed |
 |-----------|---------------------|
-| JDK | 17 (CI application job; host OpenJDK 17 via Homebrew) |
+| JDK | 17 (all CI jobs Temurin; host OpenJDK 17 via Homebrew) |
 | Gradle | plugins 8.3, application 8.4 |
 | AGP | sample 8.1.2 (forced); plugins compile against 7.4.2 |
 | Kotlin | embeddedKotlin from Gradle distribution |
@@ -312,7 +314,7 @@ Suggested extraction order (tickets F-020…F-024):
 | README dependency matrix ≠ live validators | F-010 |
 | `EmptyValidator` on app/binary/androidLibrary | F-011 |
 | AGP 7.4.2 compile vs 8.1.2 runtime | F-003 |
-| CI missing SDK + Java on some jobs | F-004 |
+| ~~CI missing SDK + Java on some jobs~~ (workflow fixed; await GHA green) | F-004 |
 | Compose flag in settings, limited target support | F-013 |
 | Shared `library` suffix for JVM vs Android library | F-020 |
 | Plugin publish / Portal path | F-016 |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -314,7 +314,7 @@ Suggested extraction order (tickets F-020…F-024):
 | README dependency matrix ≠ live validators | F-010 |
 | `EmptyValidator` on app/binary/androidLibrary | F-011 |
 | AGP 7.4.2 compile vs 8.1.2 runtime | F-003 |
-| ~~CI missing SDK + Java on some jobs~~ (workflow fixed; await GHA green) | F-004 |
+| ~~CI missing SDK + Java on some jobs~~ (GHA green on PR #153) | F-004 done |
 | Compose flag in settings, limited target support | F-013 |
 | Shared `library` suffix for JVM vs Android library | F-020 |
 | Plugin publish / Portal path | F-016 |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -4,7 +4,7 @@ Newest entries first.
 
 ## 2026-07-11 — F-004 CI green (workflow + badge)
 
-- **Ticket:** F-004 → `in_progress` (workflow shipped; full green claim waits on GHA run after PR)
+- **Ticket:** F-004 → `done`
 - **Branch:** `forma/F-004-ci-green` (from `origin/v2`; independent of open F-003 PR #152)
 - **Actions:**
   - Rewrote `.github/workflows/main.yml`:
@@ -16,11 +16,14 @@ Newest entries first.
     - Dropped unconditional `--scan`; use `--stacktrace --console=plain`
   - README CI badge + code-size shield → `formatools/forma` + `actions/workflows/main.yml/badge.svg`
   - `docs/ARCHITECTURE.md` §4 updated for new CI layout
-- **Local verification:** host still has JDK 17 + SDK 33 from F-001; full GHA run not available until push/PR
-- **Commits/PRs:** this run — push + PR base `v2`
-- **Blockers:** none for the workflow change itself; mark F-004 `done` only after GHA jobs are green on the PR
-- **Next step:** merge order note — F-003 (#152 AGP 8.1.2 compile align) still open on `v2`; CI PR can land independently. After both merge, re-check application job on combined tip
-- **Related open PRs:** #150 F-001, #151 F-002 (already in `v2` tip), #152 F-003
+- **GHA verification (PR run 29162702015):** **all success**
+  - Plugins: success
+  - Includer: success
+  - Depgen: success
+  - Application: success (SDK setup + full sample build)
+- **Commits/PRs:** https://github.com/formatools/forma/pull/153
+- **Blockers:** none
+- **Next step:** P0 complete after #152 (F-003) + #153 (F-004) merge to `v2`. Then P1 top is F-010 (live dependency matrix docs). Related open: #150/#151 already in `v2` tip; #152 F-003 still open.
 
 ## 2026-07-11 — v2 base of operations (merge open PRs)
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest entries first.
 
+## 2026-07-11 — F-004 CI green (workflow + badge)
+
+- **Ticket:** F-004 → `in_progress` (workflow shipped; full green claim waits on GHA run after PR)
+- **Branch:** `forma/F-004-ci-green` (from `origin/v2`; independent of open F-003 PR #152)
+- **Actions:**
+  - Rewrote `.github/workflows/main.yml`:
+    - Display name **CI**; triggers `push` + `pull_request` + `workflow_dispatch`
+    - Concurrency cancel-in-progress per ref
+    - **All four jobs** pin Temurin 17 (`actions/setup-java@v4`)
+    - Gradle via `gradle/actions/setup-gradle@v4`
+    - `build_application`: `android-actions/setup-android@v3` with `platforms;android-33`, platform-tools, build-tools 33.0.2 + 34.0.0
+    - Dropped unconditional `--scan`; use `--stacktrace --console=plain`
+  - README CI badge + code-size shield → `formatools/forma` + `actions/workflows/main.yml/badge.svg`
+  - `docs/ARCHITECTURE.md` §4 updated for new CI layout
+- **Local verification:** host still has JDK 17 + SDK 33 from F-001; full GHA run not available until push/PR
+- **Commits/PRs:** this run — push + PR base `v2`
+- **Blockers:** none for the workflow change itself; mark F-004 `done` only after GHA jobs are green on the PR
+- **Next step:** merge order note — F-003 (#152 AGP 8.1.2 compile align) still open on `v2`; CI PR can land independently. After both merge, re-check application job on combined tip
+- **Related open PRs:** #150 F-001, #151 F-002 (already in `v2` tip), #152 F-003
+
 ## 2026-07-11 — v2 base of operations (merge open PRs)
 
 - **Action:** Created integration branch `v2` from `origin/master`, merged open work from:


### PR DESCRIPTION
## Summary
- Rewrite `.github/workflows/main.yml` as **CI**: Temurin 17 on all four jobs, `gradle/actions/setup-gradle@v4`, concurrency cancel-in-progress, `pull_request` trigger
- Application job installs Android SDK via `android-actions/setup-android@v3` (`platforms;android-33`, platform-tools, build-tools 33.0.2 + 34.0.0)
- Drop unconditional `--scan`; use `--stacktrace --console=plain`
- Point README badge/code-size shields at `formatools/forma` + `actions/workflows/main.yml`
- Update `docs/ARCHITECTURE.md` CI section + progress log; ticket F-004 stays `in_progress` until GHA is green on this PR

## Test plan
- [ ] GHA `Plugins` / `Includer` / `Depgen` jobs green (JDK-only)
- [ ] GHA `Application` job green (JDK + Android SDK 33)
- [ ] Badge URL resolves after merge to default/integration branch

## Notes
Independent of open F-003 PR #152 (AGP compile align). Can merge either order; re-check application job after both land on `v2`.