### PR TITLE
F-021: extract restriction engine into plugins/core

### DIFF
--- a/README.md
+++ b/README.md
@@ -195,8 +195,8 @@ Plugin Portal publish path: **F-016**
 ([`docs/PLUGIN-PUBLISH.md`](docs/PLUGIN-PUBLISH.md)).
 Configuration-time performance: **F-017**
 ([`docs/CONFIGURATION-PERFORMANCE.md`](docs/CONFIGURATION-PERFORMANCE.md)).
-forma-core API design (extraction next): **F-020**
-([`docs/forma-core-api.md`](docs/forma-core-api.md)).
+forma-core API design: **F-020** ([`docs/forma-core-api.md`](docs/forma-core-api.md)).
+forma-core extraction (restriction engine + TargetType + Android matrix kit): **F-021** done (`plugins/core`).
 
 Icons made by <a href="https://www.flaticon.com/authors/freepik" title="Freepik">Freepik</a>
 from <a href="https://www.flaticon.com/" title="Flaticon">www.flaticon.com</a>

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -31,7 +31,7 @@ Update this file when picking or finishing work. Cron workers must pick the **hi
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
 | F-020 | done | Design forma-core public API (types, restrictions, validation, target registry) | `docs/forma-core-api.md` — types, restriction graph, validator SPI, registry, coords, library-suffix decision |
-| F-021 | todo | Extract dependency-type / restriction engine into `forma-core` | Related GH #39, closed #34 |
+| F-021 | done | Extract dependency-type / restriction engine into `forma-core` | `plugins/core` + TargetType/NameMatcher/RestrictionGraph + AndroidTargetTypes + AndroidRestrictionKit (distinct jvm.library vs android.library); facades preserved. Related GH #39 |
 | F-022 | todo | Extract validation framework into `forma-core` | Keep Android validators as plugins |
 | F-023 | todo | Wire Android implementation as first consumer of forma-core | Sample still builds |
 | F-024 | todo | Publish/coordinate coordinates: `tools.forma:core` vs android plugins | |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -60,7 +60,7 @@ that compose via `includeBuild`:
 
 - `pluginManagement { includeBuild("../build-settings") }`
 - `tools.forma.includer` **0.2.0** from Portal (not local includer composite)
-- Includer discovers `:android`, `:config`, `:deps`, `:owners`, `:target`, `:validation`
+- Includer discovers `:android`, `:config`, `:core`, `:deps`, `:owners`, `:target`, `:validation` (F-021 added `:core`)
 
 ---
 
@@ -70,7 +70,11 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
 
 ```
                     ┌────────────┐
-                    │   target   │  TargetTemplate, FormaTarget
+                    │    core    │  TargetType, NameMatcher, RestrictionGraph (F-021)
+                    └─────▲──────┘
+                          │
+                    ┌─────┴──────┐
+                    │   target   │  TargetTemplate, FormaTarget (parallel for compat)
                     └─────▲──────┘
                           │
               ┌───────────┼────────────┐
@@ -86,18 +90,19 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
               └─────┬─────┴────────────┘
                     │
               ┌─────┴─────┐
-              │  android  │  user-facing DSL + AGP features
+              │  android  │  user-facing DSL + AGP features (+ AndroidTargetTypes + matrix)
               └───────────┘
 ```
 
 | Module | Plugin id | Depends on | Responsibility |
 |--------|-----------|------------|----------------|
-| `:target` | `tools.forma.target` | `gradleApi` | `TargetTemplate(suffix)`, `FormaTarget(project)` |
-| `:validation` | `tools.forma.validation` | `:target`, `gradleApi` | Name validators, content validators, `ProjectValidationError` |
+| `:core` | (library, not plugin) | (none / gradleApi compileOnly if needed) | `TargetType` / `TargetRef`, `NameMatcher`/`SuffixNameMatcher`, `RestrictionGraph`/`MutableRestrictionGraph`, `EdgeKind`, `RestrictionRule`. Pure engine. |
+| `:target` | `tools.forma.target` | `gradleApi` | `TargetTemplate(suffix)`, `FormaTarget(project)` (compat facade; F-021 adds parallel core types) |
+| `:validation` | `tools.forma.validation` | `:target`, `gradleApi` | Name validators, content validators, `ProjectValidationError` (F-022 will migrate to core) |
 | `:owners` | `tools.forma.owners` | `gradleApi` | `Owner` / `Person` / `Team` / `NoOwner` |
 | `:config` | `tools.forma.config` | `gradleApi` | `AndroidProjectSettings`, `FormaSettingsStore`, plugin/dep registration maps |
 | `:deps` | `tools.forma.deps` | `:validation`, `:target`, `:config`, kotlin-dsl | `FormaDependency` model, `applyDependencies`, version-catalog generators |
-| `:android` | `tools.forma.android` | all of the above + **AGP** + Kotlin GP | Target DSL (`api`, `impl`, `androidLibrary`, …), feature appliers |
+| `:android` | `tools.forma.android` | `:core` + all of the above + **AGP** + Kotlin GP | Target DSL (`api`, `impl`, `androidLibrary`, …), feature appliers; owns `AndroidTargetTypes` + `AndroidRestrictionKit` (F-021) |
 
 `:android` compiles against **AGP 8.1.2** (aligned with sample runtime force in
 `application/settings.gradle.kts` as of F-003). Keep `plugins/android` AGP
@@ -302,7 +307,7 @@ Aligned with `docs/VISION.md`: core must not assume Android/AGP/Dagger.
 
 | Concern | Current home | forma-core? | Notes |
 |---------|--------------|-------------|-------|
-| Target type identity (`TargetTemplate` / suffix) | `:target` | **Yes** | Registry API (F-020/F-021) |
+| Target type identity (`TargetTemplate` / suffix) | `:target` + `:core` (F-021) | **Yes** | Parallel `TargetType` in core; templates kept for compat in F-021. Registry in F-022/F-023. |
 | Name + dep-type `Validator` | `:validation` | **Yes** | Keep framework; Android content rules as plugins |
 | Content validators (`onlyAllowResources`, …) | `:android` + `:validation` helpers | **Split** | Generic dir checks → core; Android paths → android plugin |
 | Dependency model + apply | `:deps` | **Mostly yes** | Strip AGP-ish config features; catalog generators may stay tooling |
@@ -318,7 +323,7 @@ Suggested extraction order (tickets F-020…F-024):
 1. Document public API — **done (F-020):** [`forma-core-api.md`](forma-core-api.md)
    (types, restriction graph, validator SPI, target registry, coords preview,
    `library` suffix decision).
-2. Move `:target` + pure validation + restriction tables into `forma-core` (F-021).
+2. Create `plugins/core` + TargetType + RestrictionGraph + wire Android matrix from DEPENDENCY-MATRIX (F-021). Parallel types + facades; full move later.
 3. Re-home `applyDependencies` project-validation path on core validators (F-022).
 4. Leave `:android` as the first platform package implementing templates + AGP features (F-023).
 5. Coordinates: e.g. `tools.forma:core` vs `tools.forma.android` (F-024).

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,33 @@
 
 Newest entries first.
 
+## 2026-07-13 — F-021 Extract dependency-type / restriction engine into forma-core
+
+- **Ticket:** F-021 → `done`
+- **Branch:** `forma/F-021-forma-core-restriction` (from `origin/v2`)
+- **Skills/modes:** Grok Build `--mode full` (plan agent design → implement + goal + check); Hermes verified builds; matrix id split fix applied on disk after implement timeout
+- **New module:**
+  - `plugins/core/` pure JVM library (`tools.forma` / `0.1.3`), no AGP / no plugin-publish
+  - Auto-included via `tools.forma.includer`
+- **Core packages (`tools.forma.core.*`):**
+  - `target`: `TargetType`, `TargetRef`, `SimpleTargetType`, `targetType(...)`, `NameMatcher`, `SuffixNameMatcher`
+  - `restriction`: `EdgeKind`, `RestrictionRule`, `RestrictionGraph`, `MutableRestrictionGraph` (closed-world, id-keyed)
+- **Android wiring (platform owns types + matrix):**
+  - `AndroidTargetTypes`: stable ids (`android.api`, `android.impl`, `android.library`, **`jvm.library`**, `jvm.util`, …)
+  - `AndroidRestrictionKit.register` / `build()` from `docs/DEPENDENCY-MATRIX.md`; **impl ↛ impl**; JVM `library` vs `androidLibrary` rules not merged
+  - `:android` depends on `:core`
+- **Compat:** legacy `TargetTemplate` / `validator(...)` / DSL untouched (F-023 consumes graph)
+- **Tests:** `NameMatcherTest` + `RestrictionGraphTest` (impl rule + §7 suffix collision)
+- **Docs:** ARCHITECTURE graph/table/extraction; README Progress; TICKETS
+- **Verify (Hermes re-run, OpenJDK 17):**
+  - `plugins/`: `./gradlew :core:test` → **BUILD SUCCESSFUL**
+  - `plugins/`: `./gradlew build` → **BUILD SUCCESSFUL** (67 tasks)
+  - `plugins/`: `./gradlew :android:compileKotlin` → **BUILD SUCCESSFUL**
+  - `application/`: `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (578 tasks)
+- **Commits/PRs:** this run — push + PR base `v2`
+- **Blockers:** none (Grok CLI auth needed env-parse fix in `~/.hermes/scripts/grok_build_exec.sh`; implement phase hit turn/timeout once but tree landed)
+- **Next step:** F-022 Extract validation framework into forma-core
+
 ## 2026-07-13 — F-020 Design forma-core public API
 
 - **Ticket:** F-020 → `done`

--- a/plugins/android/build.gradle.kts
+++ b/plugins/android/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     implementation(project(":owners"))
     implementation(project(":config"))
     implementation(project(":deps"))
+    // F-021: core restriction + target types (pure engine); Android owns concrete type instances + matrix
+    implementation(project(":core"))
 }
 
 tasks.named<Task>("publishPlugins") {

--- a/plugins/android/src/main/java/tools/forma/android/restriction/AndroidRestrictions.kt
+++ b/plugins/android/src/main/java/tools/forma/android/restriction/AndroidRestrictions.kt
@@ -1,0 +1,114 @@
+package tools.forma.android.restriction
+
+import tools.forma.android.target.AndroidTargetTypes
+import tools.forma.core.restriction.EdgeKind
+import tools.forma.core.restriction.MutableRestrictionGraph
+import tools.forma.core.restriction.RestrictionGraph
+import tools.forma.core.target.TargetType
+
+/**
+ * Android restriction kit (F-021).
+ * Populates a MutableRestrictionGraph from the live matrix in docs/DEPENDENCY-MATRIX.md .
+ * Pure graph lives in :core; this is the Android-specific wiring.
+ *
+ * Rules are keyed by TargetType (id) not suffix, satisfying §3.3 / §7.
+ * Critical: `impl` does not allow `impl`.
+ */
+object AndroidRestrictionKit {
+
+    /** All Android TargetTypes in registration order (convenience). */
+    val all: List<TargetType> = listOf(
+        AndroidTargetTypes.api,
+        AndroidTargetTypes.impl,
+        AndroidTargetTypes.library,
+        AndroidTargetTypes.jvmLibrary,
+        AndroidTargetTypes.uiLibrary,
+        AndroidTargetTypes.native,
+        AndroidTargetTypes.util,
+        AndroidTargetTypes.testUtil,
+        AndroidTargetTypes.androidTestUtil,
+        AndroidTargetTypes.androidUtil,
+        AndroidTargetTypes.viewBinding,
+        AndroidTargetTypes.res,
+        AndroidTargetTypes.widget,
+        AndroidTargetTypes.composeWidget,
+        AndroidTargetTypes.app,
+        AndroidTargetTypes.binary
+    )
+
+    /**
+     * Register the Android dependency matrix into the provided graph.
+     * Call once during androidProjectConfiguration or plugin apply.
+     */
+    fun register(graph: MutableRestrictionGraph) {
+        val t = AndroidTargetTypes
+
+        // api: only api + library (JVM contract layer)
+        graph.allow(t.api, t.api, t.library)
+
+        // impl: api + shared + ui building blocks; NO impl (Dagger boundaries)
+        graph.allow(
+            t.impl,
+            t.api, t.androidUtil, t.testUtil, t.util, t.library,
+            t.uiLibrary, t.res, t.viewBinding, t.widget, t.composeWidget
+        )
+
+        // JVM `library` (pure Kotlin/JVM target): only util + test-util (no api/impl/res per matrix)
+        graph.allow(t.jvmLibrary, t.util, t.testUtil)
+
+        // androidLibrary: library + util + android-util + test-util + res + api (no impl, no widgets)
+        // Distinct consumer id (android.library) from jvm.library prevents merge in graph.
+        graph.allow(t.library, t.library, t.util, t.androidUtil, t.testUtil, t.res, t.api)
+
+        // uiLibrary
+        graph.allow(t.uiLibrary, t.widget, t.composeWidget, t.util, t.androidUtil, t.res)
+
+        // util (JVM): util + library
+        graph.allow(t.util, t.util, t.library)
+
+        // androidUtil
+        graph.allow(t.androidUtil, t.androidUtil, t.testUtil, t.res)
+
+        // testUtil
+        graph.allow(t.testUtil, t.testUtil, t.util)
+
+        // androidTestUtil
+        graph.allow(t.androidTestUtil, t.androidTestUtil, t.testUtil)
+
+        // androidRes
+        graph.allow(t.res, t.res, t.widget, t.composeWidget)
+
+        // widget
+        graph.allow(t.widget, t.uiLibrary, t.widget, t.composeWidget, t.util, t.androidUtil, t.res)
+
+        // composeWidget (symmetric with widget for coexistence)
+        graph.allow(t.composeWidget, t.uiLibrary, t.composeWidget, t.widget, t.util, t.androidUtil, t.res)
+
+        // viewBinding
+        graph.allow(t.viewBinding, t.api, t.widget, t.composeWidget, t.res, t.library, t.androidUtil)
+
+        // androidApp (composition root)
+        graph.allow(
+            t.app,
+            t.api, t.impl, t.library, t.util, t.androidUtil, t.testUtil, t.res,
+            t.viewBinding, t.widget, t.composeWidget, t.uiLibrary
+        )
+
+        // androidBinary (composition root)
+        graph.allow(
+            t.binary,
+            t.app, t.api, t.impl, t.library, t.util, t.androidUtil, t.testUtil, t.res,
+            t.viewBinding, t.widget, t.composeWidget, t.uiLibrary
+        )
+
+        // native: no project dep validation currently (per matrix)
+        // no allow() calls for native → empty = deny all project targets
+    }
+
+    /** Convenience: build a fresh graph pre-populated with Android rules. */
+    fun build(): RestrictionGraph {
+        val g = MutableRestrictionGraph()
+        register(g)
+        return g
+    }
+}

--- a/plugins/android/src/main/java/tools/forma/android/target/AndroidTargetTypes.kt
+++ b/plugins/android/src/main/java/tools/forma/android/target/AndroidTargetTypes.kt
@@ -1,0 +1,30 @@
+package tools.forma.android.target
+
+import tools.forma.core.target.TargetType
+import tools.forma.core.target.targetType
+
+/**
+ * Stable TargetType instances for Android platform (F-021).
+ * Ids are unique even when nameSuffix collides (e.g. "library" used by JVM + androidLibrary).
+ * These live in :android (platform owns concrete types); core holds pure engine.
+ *
+ * These parallel the legacy *TargetTemplate objects for now (F-021); full registry migration F-023.
+ */
+object AndroidTargetTypes {
+    val api: TargetType = targetType("android.api", "api")
+    val impl: TargetType = targetType("android.impl", "impl")
+    val library: TargetType = targetType("android.library", "library") // androidLibrary consumer (distinct from jvm.library)
+    val jvmLibrary: TargetType = targetType("jvm.library", "library") // JVM library() consumer
+    val uiLibrary: TargetType = targetType("android.ui-library", "ui-library")
+    val native: TargetType = targetType("android.native", "native")
+    val util: TargetType = targetType("jvm.util", "util") // JVM util target (distinct id from android.android-util)
+    val testUtil: TargetType = targetType("android.test-util", "test-util")
+    val androidTestUtil: TargetType = targetType("android.android-test-util", "android-test-util")
+    val androidUtil: TargetType = targetType("android.android-util", "android-util")
+    val viewBinding: TargetType = targetType("android.viewbinding", "viewbinding")
+    val res: TargetType = targetType("android.res", "res")
+    val widget: TargetType = targetType("android.widget", "widget")
+    val composeWidget: TargetType = targetType("android.compose-widget", "compose-widget")
+    val app: TargetType = targetType("android.app", "app")
+    val binary: TargetType = targetType("android.binary", "binary")
+}

--- a/plugins/core/build.gradle.kts
+++ b/plugins/core/build.gradle.kts
@@ -1,0 +1,15 @@
+plugins {
+    kotlin("jvm")
+}
+
+// Library (not a settings/application plugin). Use same group/version as plugins for the jar.
+group = "tools.forma"
+version = "0.1.3"
+
+dependencies {
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/plugins/core/src/main/java/tools/forma/core/restriction/RestrictionGraph.kt
+++ b/plugins/core/src/main/java/tools/forma/core/restriction/RestrictionGraph.kt
@@ -1,0 +1,82 @@
+package tools.forma.core.restriction
+
+import tools.forma.core.target.TargetType
+
+/**
+ * Kind of dependency edge. Enables future differentiation for test vs impl
+ * project dependencies (current applyDependencies only suffix-validates main deps).
+ */
+enum class EdgeKind {
+    IMPLEMENTATION,
+    TEST,
+    ANDROID_TEST
+}
+
+/**
+ * A single restriction rule: what a consumer type may depend on for given edge kinds.
+ */
+data class RestrictionRule(
+    val from: TargetType,
+    val allowedDependencies: Set<TargetType>,
+    val edgeKinds: Set<EdgeKind> = setOf(EdgeKind.IMPLEMENTATION)
+)
+
+/**
+ * Read-only view of the restriction graph.
+ */
+interface RestrictionGraph {
+    fun allowedTypes(consumer: TargetType, edge: EdgeKind = EdgeKind.IMPLEMENTATION): Set<TargetType>
+    fun isAllowed(consumer: TargetType, dependency: TargetType, edge: EdgeKind = EdgeKind.IMPLEMENTATION): Boolean
+    fun ruleFor(consumer: TargetType): RestrictionRule?
+}
+
+/**
+ * Mutable builder for restriction rules. Used by platform kits (Android, JVM) to declare
+ * their dependency matrix once at configuration time.
+ *
+ * Semantics:
+ * - Closed world: only explicitly allowed edges pass isAllowed.
+ * - Keyed by TargetType identity (unique id) per forma-core-api §3.3 and §7.
+ * - impl ↛ impl is a critical rule (enforced by not listing it).
+ */
+class MutableRestrictionGraph : RestrictionGraph {
+    private val rules: MutableMap<TargetType, RestrictionRule> = mutableMapOf()
+
+    fun allow(from: TargetType, vararg to: TargetType): MutableRestrictionGraph =
+        allow(from, to.asList())
+
+    fun allow(from: TargetType, to: Collection<TargetType>): MutableRestrictionGraph {
+        val existing = rules[from]
+        val merged = (existing?.allowedDependencies ?: emptySet()) + to.toSet()
+        rules[from] = RestrictionRule(
+            from = from,
+            allowedDependencies = merged,
+            edgeKinds = existing?.edgeKinds ?: setOf(EdgeKind.IMPLEMENTATION)
+        )
+        return this
+    }
+
+    /**
+     * Optional: declare allowed edge kinds for a consumer (defaults to IMPLEMENTATION).
+     */
+    fun allowEdges(from: TargetType, vararg edges: EdgeKind): MutableRestrictionGraph {
+        val existing = rules[from]
+        val allowed = existing?.allowedDependencies ?: emptySet()
+        rules[from] = RestrictionRule(from, allowed, edges.toSet())
+        return this
+    }
+
+    override fun allowedTypes(consumer: TargetType, edge: EdgeKind): Set<TargetType> {
+        val rule = rules[consumer] ?: return emptySet()
+        return if (edge in rule.edgeKinds) rule.allowedDependencies else emptySet()
+    }
+
+    override fun isAllowed(consumer: TargetType, dependency: TargetType, edge: EdgeKind): Boolean {
+        return dependency in allowedTypes(consumer, edge)
+    }
+
+    override fun ruleFor(consumer: TargetType): RestrictionRule? = rules[consumer]
+
+    /** Snapshot of current rules (useful for tests/debug). */
+    fun allRules(): Map<TargetType, RestrictionRule> = rules.toMap()
+}

--- a/plugins/core/src/main/java/tools/forma/core/target/NameMatcher.kt
+++ b/plugins/core/src/main/java/tools/forma/core/target/NameMatcher.kt
@@ -1,0 +1,20 @@
+package tools.forma.core.target
+
+/**
+ * Strategy for matching a Gradle project name against a TargetType.
+ * Default is suffix based to preserve existing sample naming (project == suffix or ends with -suffix).
+ */
+fun interface NameMatcher {
+    fun matches(projectName: String, type: TargetType): Boolean
+}
+
+/**
+ * Default name matcher: accepts exact suffix match or dash-suffixed (e.g. "feature-impl" matches "impl").
+ * Matches the behavior in tools.forma.validation today.
+ */
+object SuffixNameMatcher : NameMatcher {
+    override fun matches(projectName: String, type: TargetType): Boolean {
+        val s = type.nameSuffix
+        return projectName == s || projectName.endsWith("-$s", ignoreCase = false)
+    }
+}

--- a/plugins/core/src/main/java/tools/forma/core/target/TargetType.kt
+++ b/plugins/core/src/main/java/tools/forma/core/target/TargetType.kt
@@ -1,0 +1,38 @@
+package tools.forma.core.target
+
+/**
+ * Stable identity for a target type used in restriction graphs and registry.
+ * Platforms (Android, JVM, ...) own the concrete instances and their ids.
+ */
+interface TargetType {
+    /** Stable id for registry, restriction rules and docs. e.g. "android.impl", "jvm.library". */
+    val id: String
+
+    /**
+     * Gradle project name suffix used by default suffix-based name matching.
+     * e.g. "impl", "library". Not necessarily unique across platforms (see forma-core-api §7).
+     */
+    val nameSuffix: String
+
+    /** Optional human label for error messages. */
+    val displayName: String get() = id
+}
+
+/** Lightweight reference to a configured target (name is sufficient for core matching). */
+interface TargetRef {
+    val name: String
+}
+
+/** Simple data implementation of TargetType. */
+data class SimpleTargetType(
+    override val id: String,
+    override val nameSuffix: String,
+    override val displayName: String = id
+) : TargetType
+
+/** Factory for TargetType (pure, no platform assumptions). */
+fun targetType(
+    id: String,
+    nameSuffix: String,
+    displayName: String = id
+): TargetType = SimpleTargetType(id, nameSuffix, displayName)

--- a/plugins/core/src/test/java/tools/forma/core/restriction/RestrictionGraphTest.kt
+++ b/plugins/core/src/test/java/tools/forma/core/restriction/RestrictionGraphTest.kt
@@ -1,0 +1,140 @@
+package tools.forma.core.restriction
+
+import tools.forma.core.target.targetType
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class RestrictionGraphTest {
+
+    private val api = targetType("android.api", "api")
+    private val impl = targetType("android.impl", "impl")
+    private val library = targetType("android.library", "library")
+    private val util = targetType("android.util", "util")
+    private val res = targetType("android.res", "res")
+
+    // Simulate shared suffix collision per forma-core-api §7 (different ids, same suffix)
+    private val jvmLibrary = targetType("jvm.library", "library")
+    private val androidLibrary = targetType("android.library", "library")
+
+    @Test
+    fun `empty graph denies everything`() {
+        val g = MutableRestrictionGraph()
+        assertFalse(g.isAllowed(api, api))
+        assertTrue(g.allowedTypes(impl).isEmpty())
+    }
+
+    @Test
+    fun `allow basic edges and isAllowed works by TargetType id`() {
+        val g = MutableRestrictionGraph()
+        g.allow(api, api, library)
+        g.allow(impl, api, library, util, res)
+
+        assertTrue(g.isAllowed(api, api))
+        assertTrue(g.isAllowed(api, library))
+        assertFalse(g.isAllowed(api, impl)) // not listed
+        assertTrue(g.isAllowed(impl, api))
+        assertTrue(g.isAllowed(impl, res))
+        assertFalse(g.isAllowed(impl, impl)) // critical product rule
+    }
+
+    @Test
+    fun `impl never allows impl (critical Dagger boundary)`() {
+        val g = MutableRestrictionGraph()
+        g.allow(impl, api, library, util) // deliberately no impl
+
+        assertFalse(g.isAllowed(impl, impl))
+        assertFalse(g.isAllowed(impl, impl, EdgeKind.IMPLEMENTATION))
+    }
+
+    @Test
+    fun `allow is idempotent and merges`() {
+        val g = MutableRestrictionGraph()
+        g.allow(api, api)
+        g.allow(api, library)
+        g.allow(api, api) // dup
+
+        assertEquals(setOf(api, library), g.allowedTypes(api))
+    }
+
+    @Test
+    fun `suffix collision semantics - allow if ANY registered type with suffix is allowed (by name lookup sim)`() {
+        // Graph is id-keyed. Consumer of restriction (future validator) may resolve by name.
+        // Per §7: if checking a dep by name "foo-library", and any type with suffix "library" is allowed
+        // for the consumer (jvm or android), then treat as allowed (preserve current behavior).
+        val g = MutableRestrictionGraph()
+        // Consumer allows the android library type
+        g.allow(impl, api, androidLibrary, util)
+
+        // Simulate name-based resolution for a dep project named "core-library"
+        // (which could be jvm or android flavored)
+        val candidates = listOf(jvmLibrary, androidLibrary).filter { it.nameSuffix == "library" }
+
+        val allowedByName = candidates.any { g.isAllowed(impl, it) }
+        // Since androidLibrary is allowed, name "core-library" should be accepted under collision rule
+        assertTrue(allowedByName)
+
+        // If neither is allowed, deny
+        val g2 = MutableRestrictionGraph()
+        g2.allow(impl, api, util) // no library types
+        val allowedByName2 = listOf(jvmLibrary, androidLibrary).any { g2.isAllowed(impl, it) }
+        assertFalse(allowedByName2)
+    }
+
+    @Test
+    fun `ruleFor and allowedTypes respect edge default`() {
+        val g = MutableRestrictionGraph()
+        g.allow(impl, api)
+        g.allowEdges(impl, EdgeKind.IMPLEMENTATION) // explicit but default
+
+        assertEquals(setOf(api), g.allowedTypes(impl))
+        assertEquals(setOf(api), g.allowedTypes(impl, EdgeKind.IMPLEMENTATION))
+        assertTrue(g.allowedTypes(impl, EdgeKind.TEST).isEmpty())
+    }
+
+    @Test
+    fun `allRules snapshot`() {
+        val g = MutableRestrictionGraph()
+        g.allow(api, api)
+        assertEquals(1, g.allRules().size)
+        assertEquals(api, g.allRules().keys.first())
+    }
+
+    @Test
+    fun `jvm library and android library consumers have distinct non-merged allow lists`() {
+        // Documents F-021 fix: separate ids (jvm.library vs android.library) for same suffix
+        // ensures graph.allow() for one does not merge into the other (see DEPENDENCY-MATRIX
+        // and forma-core-api.md §7). Uses synthetic types (core test stays independent of android kit).
+        val jvmLib = targetType("jvm.library", "library")
+        val androidLib = targetType("android.library", "library")
+        val jvmUtil = targetType("jvm.util", "util")
+        val androidUtil = targetType("android.android-util", "android-util")
+        val testUtilT = targetType("android.test-util", "test-util")
+        val resT = targetType("android.res", "res")
+
+        val g = MutableRestrictionGraph()
+
+        // JVM library matrix (per library.kt + DEPENDENCY-MATRIX)
+        g.allow(jvmLib, jvmUtil, testUtilT)
+
+        // androidLibrary matrix (per androidLibrary.kt + DEPENDENCY-MATRIX)
+        g.allow(androidLib, androidLib, jvmUtil, androidUtil, testUtilT, resT, api)
+
+        // Verify distinct rules (no accidental merge from duplicate consumer id)
+        val jvmAllowed = g.allowedTypes(jvmLib)
+        val androidAllowed = g.allowedTypes(androidLib)
+
+        assertEquals(setOf(jvmUtil, testUtilT), jvmAllowed)
+        assertTrue(androidAllowed.contains(androidLib))
+        assertTrue(androidAllowed.contains(jvmUtil))
+        assertTrue(androidAllowed.contains(androidUtil))
+        assertTrue(androidAllowed.contains(testUtilT))
+        assertTrue(androidAllowed.contains(resT))
+        assertTrue(androidAllowed.contains(api))
+        assertEquals(6, androidAllowed.size)
+        assertFalse(jvmAllowed.contains(api))
+        assertFalse(jvmAllowed.contains(resT))
+        assertFalse(jvmAllowed == androidAllowed)
+    }
+}

--- a/plugins/core/src/test/java/tools/forma/core/target/NameMatcherTest.kt
+++ b/plugins/core/src/test/java/tools/forma/core/target/NameMatcherTest.kt
@@ -1,0 +1,45 @@
+package tools.forma.core.target
+
+import kotlin.test.Test
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+class NameMatcherTest {
+
+    private val api = targetType("android.api", "api")
+    private val impl = targetType("android.impl", "impl")
+    private val library = targetType("android.library", "library")
+    private val composeWidget = targetType("android.compose-widget", "compose-widget")
+
+    @Test
+    fun `SuffixNameMatcher matches exact suffix`() {
+        assertTrue(SuffixNameMatcher.matches("api", api))
+        assertTrue(SuffixNameMatcher.matches("impl", impl))
+        assertTrue(SuffixNameMatcher.matches("library", library))
+        assertTrue(SuffixNameMatcher.matches("compose-widget", composeWidget))
+    }
+
+    @Test
+    fun `SuffixNameMatcher matches dashed suffix`() {
+        assertTrue(SuffixNameMatcher.matches("feature-home-api", api))
+        assertTrue(SuffixNameMatcher.matches("feature-characters-impl", impl))
+        assertTrue(SuffixNameMatcher.matches("core-library", library))
+        assertTrue(SuffixNameMatcher.matches("common-greeting-compose-widget", composeWidget))
+    }
+
+    @Test
+    fun `SuffixNameMatcher rejects non-matching`() {
+        assertFalse(SuffixNameMatcher.matches("impl", api))
+        assertFalse(SuffixNameMatcher.matches("api", impl))
+        assertFalse(SuffixNameMatcher.matches("feature", library))
+        assertFalse(SuffixNameMatcher.matches("library", composeWidget))
+        assertFalse(SuffixNameMatcher.matches("compose-widget", api))
+    }
+
+    @Test
+    fun `SuffixNameMatcher is case sensitive on suffix part`() {
+        // current behavior (ignoreCase=false in endsWith)
+        assertFalse(SuffixNameMatcher.matches("Feature-Api", api))
+        assertFalse(SuffixNameMatcher.matches("LIB", library))
+    }
+}


### PR DESCRIPTION
## Summary
- New `plugins/core` JVM library: `TargetType` / `TargetRef`, `NameMatcher` / `SuffixNameMatcher`, `RestrictionGraph` / `MutableRestrictionGraph` / `EdgeKind` / `RestrictionRule` (forma-core-api.md F-021 slice).
- Android platform kit: `AndroidTargetTypes` + `AndroidRestrictionKit` encoding `docs/DEPENDENCY-MATRIX.md` with **distinct** `jvm.library` vs `android.library` ids; **impl ↛ impl**.
- Legacy `TargetTemplate` / `validator(...)` / DSL entrypoints unchanged (runtime consumption = F-023).
- Unit tests for matcher, closed-world graph, suffix collision, non-merged library matrices.
- Docs: ARCHITECTURE module graph, TICKETS, PROGRESS, README Progress.

## Verify (worker host, OpenJDK 17)
- `plugins/`: `./gradlew :core:test` + `./gradlew build` → BUILD SUCCESSFUL
- `application/`: `./gradlew :binary:assembleDebug` → BUILD SUCCESSFUL (578 tasks)

## Next
F-022 validation SPI extraction; F-023 wire DSL to registry/graph.