### PR TITLE
docs: empty ticket queue + close done GH issues note

### DIFF
--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,24 @@
 
 Newest entries first.
 
+## 2026-07-15 — Ticket queue empty; close done GitHub issues
+
+- **Ticket:** none open in P0–P4 (`TICKETS.md` all `done` through F-042)
+- **Branch:** `v2` (clean, up to date with `origin/v2` @ `92c82d7`)
+- **Skills/modes:** Hermes orchestrator only (no Grok Build — nothing to implement)
+- **Actions:**
+  - Confirmed no open PRs (base v2 or otherwise)
+  - Closed GitHub issues already delivered on `v2`:
+    - #53 → F-015 (PR #159)
+    - #96 → F-013 (PR #157)
+    - #106 + #42 → F-017 (PR #161)
+    - #132 → F-016 (PR #160); #133 Portal org remains human/admin open
+    - #39 → covered by F-020..F-024 forma-core extraction
+    - #18 → F-022 validation framework
+  - Left true backlog issues open (#110, #97, #88, #82, #77, #54, #51, #46, #44/#43, #36, #126, #111, #103, #48, #56, #133)
+- **Blockers:** no prioritized `todo`/`in_progress` tickets — need new F-xxx tickets or explicit backlog prioritization to continue product work
+- **Next step:** user adds next-phase tickets (or promotes a backlog GH item into `TICKETS.md`)
+
 ## 2026-07-14 — F-042 Minimal Bazel sample using forma-core concepts
 
 - **Ticket:** F-042 → `done`


### PR DESCRIPTION
## Summary
- All P0-P4 tickets in TICKETS.md are already done (through F-042 on v2).
- This PR only appends a docs/PROGRESS.md entry for the 2026-07-15 cron run.
- No product code. GitHub issues already delivered on v2 were closed out-of-band (53, 96, 106, 42, 132, 39, 18); 133 remains open (Portal admin).

## Test plan
- [x] Docs-only change; no build required
