### PR TITLE
F-018: schedule JDK 21 + Gradle/AGP modernization

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -12,6 +12,7 @@ Update this file when picking or finishing work. Cron workers must pick the **hi
 | F-002 | done | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
 | F-003 | done | Get plugins + sample `application/` building on modern toolchain | Plugins compile AGP 8.1.2 matches sample; Gradle 8.3 (plugins) / 8.4 (app); host builds green |
 | F-004 | done | CI green on GitHub Actions for plugins + application | Temurin 17 all jobs + Android SDK 33 for app; PR #153 GHA green |
+| F-018 | todo | JDK 21 + Gradle/AGP staged modernization | **User-prioritized 2026-07-19.** Host/CI → **JDK 21** (latest practical LTS; AGP still docs min/default **17** even on 9.2). Requires Gradle **≥8.5** first (wrappers today 8.3/8.4). Then AGP ladder 8.5→8.7→8.13; AGP 9 = optional F-019. Plan: `~/.hermes/plans/2026-07-13_024508-forma-gradle-agp-upgrade.md` |
 
 ## P1 — Android working product
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,22 @@
 
 Newest entries first.
 
+## 2026-07-19 — F-018 scheduled (JDK 21 + toolchain ladder)
+
+- **Ticket:** F-018 → `todo` (inserted under P0 by user request: “Schedule JDK upgrade for the latest supported by AGP”)
+- **Facts (official):**
+  - AGP **8.1.2** (current Forma) through **9.2.x**: compatibility tables list JDK **min 17 / default 17**
+  - Gradle **8.3/8.4** (current wrappers): run JVM up through **20**; **JDK 21 requires Gradle ≥8.5**
+  - Current Gradle line supports run JVMs through **26** (9.4+); not a target until AGP 9 / Gradle 9 (F-019)
+- **Decision:** upgrade host + CI build JDK to **21** (current LTS above 17 that AGP runs on once Gradle is new enough). Keep Android `source`/`target` / toolchain language at **17** unless a later phase deliberately raises bytecode level.
+- **Ship order (one phase per PR preferred):**
+  1. Unify wrappers → **Gradle 8.7** (enables JDK 21 daemon)
+  2. Host `scripts/env-mac.sh` + docs + CI `actions/setup-java` → **Temurin/OpenJDK 21**
+  3. AGP lockstep **8.5.2** → later **8.7** → **8.13** (existing plan phases 2–4)
+  4. Do **not** start AGP 9 without explicit OK (F-019)
+- **Not done this note:** no Gradle/JDK install yet — queue + schedule only
+- **Next:** worker implements Phase 1 (Gradle 8.7) then JDK 21 host/CI on same or follow-up PR
+
 ## 2026-07-17 — F-063: hard-remove `androidLibrary`
 
 - **Ticket:** F-063 → `done` (P6 flat-structure complete)


### PR DESCRIPTION
## Summary
- Adds **F-018** (`todo`) under P0: JDK 21 host/CI + staged Gradle/AGP ladder
- Documents decision in `docs/PROGRESS.md` (AGP official JDK stays 17 min/default; practical upgrade = **21**; Gradle must move to ≥8.5 first)

## Why JDK 21
AGP 8.x–9.2 compatibility tables list JDK **17** min/default. “Latest supported” practical LTS for running Gradle/AGP is **21** (25/26 need Gradle 9.x → F-019). Current wrappers 8.3/8.4 cannot run on 21.

## Next
Worker implements Phase 1 (Gradle 8.7 unify) then host/`env-mac.sh`/CI → 21. AGP bumps remain later F-018 phases. AGP 9 only as F-019 with explicit OK.

## Test plan
- [x] Docs-only PR
- [ ] Follow-up implementation PRs verify `plugins` + `application` builds on JDK 21