### PR TITLE
F-018: unify Gradle wrappers to 8.7

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -12,7 +12,7 @@ Update this file when picking or finishing work. Cron workers must pick the **hi
 | F-002 | done | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
 | F-003 | done | Get plugins + sample `application/` building on modern toolchain | Plugins compile AGP 8.1.2 matches sample; Gradle 8.3 (plugins) / 8.4 (app); host builds green |
 | F-004 | done | CI green on GitHub Actions for plugins + application | Temurin 17 all jobs + Android SDK 33 for app; PR #153 GHA green |
-| F-018 | todo | JDK 21 + Gradle/AGP staged modernization | **User-prioritized 2026-07-19.** Host/CI → **JDK 21** (latest practical LTS; AGP still docs min/default **17** even on 9.2). Requires Gradle **≥8.5** first (wrappers today 8.3/8.4). Then AGP ladder 8.5→8.7→8.13; AGP 9 = optional F-019. Plan: `~/.hermes/plans/2026-07-13_024508-forma-gradle-agp-upgrade.md` |
+| F-018 | in_progress | JDK 21 + Gradle/AGP staged modernization | **Phase 1 done (this PR):** all wrappers → **Gradle 8.7**; KSP **1.9.22-1.0.16**; Compose compiler **1.5.10**; kotlin-stdlib forces for failOnVersionConflict. Next: host/CI JDK 21; AGP 8.5.2+. Plan: `~/.hermes/plans/2026-07-13_024508-forma-gradle-agp-upgrade.md` |
 
 ## P1 — Android working product
 

--- a/application/gradle/wrapper/gradle-wrapper.properties
+++ b/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/application/settings.gradle.kts
+++ b/application/settings.gradle.kts
@@ -36,7 +36,12 @@ buildscript {
                     "com.google.errorprone:error_prone_annotations:2.11.0",
                     "commons-codec:commons-codec:1.15",
                     "com.android.tools.build:aapt2-proto:8.1.2-10154469",
+                    // Gradle 8.7 embeds Kotlin 1.9.22 — force stdlib family lockstep under failOnVersionConflict
+                    "org.jetbrains.kotlin:kotlin-stdlib:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$embeddedKotlinVersion",
                     "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-stdlib-common:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-reflect:$embeddedKotlinVersion",
                     "com.android.tools.build:gradle:8.1.2",
                     "org.jetbrains.kotlin:kotlin-gradle-plugin:$embeddedKotlinVersion",
                     "com.squareup:javapoet:1.13.0"
@@ -90,7 +95,8 @@ projectDependencies(
     plugin("com.google.firebase:firebase-crashlytics-gradle", "2.9.9"),
     plugin(
         id = "com.google.devtools.ksp:symbol-processing-gradle-plugin",
-        version = "$embeddedKotlinVersion-1.0.13",
+        // Gradle 8.7 embedded Kotlin is 1.9.22; KSP line starts at 1.9.22-1.0.16 (1.0.13 does not exist)
+        version = "1.9.22-1.0.16",
         configuration = ksp,
         "androidx.room:room-compiler:$roomVersion"
     )

--- a/bazel-adapter/gradle/wrapper/gradle-wrapper.properties
+++ b/bazel-adapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/build-dependencies/dependencies/src/main/kotlin/Versions.kt
+++ b/build-dependencies/dependencies/src/main/kotlin/Versions.kt
@@ -39,7 +39,7 @@ object versions {
         const val vectordrawable = "1.1.0"
         const val versionedparcelable = "1.1.0"
         const val viewpager = "1.0.0"
-        // Compose set for sample (Kotlin 1.9.10 / compiler 1.5.3)
+        // Compose set for sample (Kotlin 1.9.22 / compiler 1.5.10 — Gradle 8.7 embedded Kotlin)
         // Pin artifacts directly (Forma MixedDependency does not yet carry PlatformSpec)
         const val compose = "1.5.3"
     }

--- a/build-dependencies/gradle/wrapper/gradle-wrapper.properties
+++ b/build-dependencies/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/build-settings/gradle/wrapper/gradle-wrapper.properties
+++ b/build-settings/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/depgen/gradle/wrapper/gradle-wrapper.properties
+++ b/depgen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,9 +16,9 @@ that compose via `includeBuild`:
 
 | Path | Role | Gradle wrapper | Publishes / consumed as |
 |------|------|----------------|-------------------------|
-| `plugins/` | Forma Gradle plugins (main product) | 8.3 | Composite + Plugin Portal (`tools.forma.*`) |
-| `application/` | Sample Android product (gold standard) | 8.4 | Consumer only |
-| `jvm-application/` | Sample pure-JVM product (`tools.forma.jvm`) | 8.4 | Consumer only |
+| `plugins/` | Forma Gradle plugins (main product) | 8.7 | Composite + Plugin Portal (`tools.forma.*`) |
+| `application/` | Sample Android product (gold standard) | 8.7 | Consumer only |
+| `jvm-application/` | Sample pure-JVM product (`tools.forma.jvm`) | 8.7 | Consumer only |
 | `includer/` | Settings plugin: auto-`include` subprojects | (own wrapper) | `tools.forma.includer` |
 | `depgen/` | Transitive-deps generation plugin | (own wrapper) | `tools.forma.depgen` (standalone) |
 | `build-settings/` | Shared settings conventions (repos) | — | `includeBuild` / convention plugins |
@@ -296,7 +296,7 @@ keys) or full Portal publish via secrets; deeper Gradle remote cache.
 | Component | Declared / observed |
 |-----------|---------------------|
 | JDK | 17 (all CI jobs Temurin; host OpenJDK 17 via Homebrew) |
-| Gradle | plugins 8.3, application 8.4 |
+| Gradle | **8.7** (all wrappers; F-018 Phase 1) |
 | AGP | **8.1.2** sample runtime + plugins compile (aligned F-003) |
 | Kotlin | embeddedKotlin from Gradle distribution |
 | Android SDK | sample compileSdk **34** / target 33; host platforms 34+33 + build-tools 33/34 |

--- a/docs/COMPOSE.md
+++ b/docs/COMPOSE.md
@@ -16,7 +16,7 @@ androidProjectConfiguration(
     compileSdk = 34,
     agpVersion = "8.1.2",
     compose = false, // default for per-target flags
-    composeCompilerVersion = "1.5.3", // must match Kotlin (1.9.10 → 1.5.3)
+    composeCompilerVersion = "1.5.10", // must match Kotlin (1.9.22 → 1.5.10)
 )
 ```
 
@@ -97,7 +97,7 @@ Full matrix: [`DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md).
 
 ## Compiler / Kotlin pairing
 
-Default `composeCompilerVersion = "1.5.3"` matches Kotlin **1.9.10** (Gradle 8.4
+Default `composeCompilerVersion = "1.5.10"` matches Kotlin **1.9.22** (Gradle 8.7
 embedded Kotlin used by the sample). If you bump Kotlin, update
 `composeCompilerVersion` using the
 [Compose Compiler compatibility map](https://developer.android.com/jetpack/androidx/releases/compose-kotlin).

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -71,8 +71,8 @@ sudo ln -sfn /usr/local/opt/openjdk@17/libexec/openjdk.jdk \
 - `includer/`: `./gradlew build` → **BUILD SUCCESSFUL**
 - `depgen/`: `./gradlew build` → **BUILD SUCCESSFUL**
 - `application/`: `./gradlew build` → **BUILD SUCCESSFUL** (compileSdk **34**,
-  targetSdk 33, Compose compiler 1.5.3, 2151 tasks)
-- Gradle wrappers: plugins 8.3, application 8.4
+  targetSdk 33, Compose compiler **1.5.10** / Kotlin **1.9.22**, F-018)
+- Gradle wrappers: **8.7** (all roots; was 8.3/8.4 split)
 - Toolchain note: plugins compile AGP matches sample forced AGP (no 7.4.2 skew)
 
 ## Shell profile

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -162,7 +162,7 @@ buildscript {
         compileSdk = 34,          // 34 if you use modern Compose transitive AARs
         agpVersion = "8.1.2",     // keep aligned with plugin compile AGP
         // compose = false,       // project default for per-target compose flags
-        // composeCompilerVersion = "1.5.3", // match your Kotlin (1.9.10 → 1.5.3)
+        // composeCompilerVersion = "1.5.10", // match your Kotlin (1.9.22 → 1.5.10)
         extraPlugins = listOf(
             // optional: navigation safe-args, KSP, crashlytics, …
         ),
@@ -413,7 +413,7 @@ Details: [COMPOSE.md](COMPOSE.md). Sample:
 | Project not included | Missing `build.gradle.kts`, or nested `settings.gradle.kts` blocked Includer |
 | Illegal project dependency | Matrix violation — see [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md) |
 | Empty / wrong package | `packageName` ≠ directory under `src/main/java` |
-| Compose compiler mismatch | Align `composeCompilerVersion` with Kotlin (sample: 1.5.3 ↔ 1.9.10) |
+| Compose compiler mismatch | Align `composeCompilerVersion` with Kotlin (sample: 1.5.10 ↔ 1.9.22) |
 | AGP resolution conflicts | Align consumer `agpVersion` with plugin AGP line (**8.1.2** today) |
 
 ---

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,21 @@
 
 Newest entries first.
 
+## 2026-07-19 — F-018 Phase 1: unify Gradle wrappers → 8.7
+
+- **Ticket:** F-018 → `in_progress` (Phase 1 shipped; JDK 21 + AGP climb remain)
+- **Why delayed:** Jul 12 session wrote the plan + asked priority buttons instead of implementing; F-018 was not on `TICKETS.md` until 2026-07-19, so 4h workers continued forma-core/Bazel/flat-structure. User call-out: do the work, don't re-plan.
+- **Code:**
+  - All `gradle-wrapper.properties` (plugins, application, includer, depgen, jvm-application, bazel-adapter, examples/*, build-*, root) → **Gradle 8.7**
+  - `application/settings.gradle.kts`: force full kotlin-stdlib family to `$embeddedKotlinVersion` (1.9.22) under `failOnVersionConflict`; KSP **1.9.22-1.0.16** (1.0.18 caused kapt↔ksp task cycle)
+  - Default Compose compiler **1.5.3 → 1.5.10** (Kotlin 1.9.22 map); example 06-compose aligned
+- **Verify (real, OpenJDK 17 + env-mac.sh):**
+  - `plugins/ ./gradlew --version` → **8.7** / Kotlin 1.9.22
+  - `plugins/ ./gradlew build` → **BUILD SUCCESSFUL**
+  - `application/ ./gradlew build` → **BUILD SUCCESSFUL** (2203 tasks)
+  - `includer`, `depgen`, `bazel-adapter`, `jvm-application` builds → **BUILD SUCCESSFUL**
+- **Next:** F-018 Phase 1b host/CI JDK 21; Phase 2 AGP 8.5.2 lockstep
+
 ## 2026-07-19 — F-018 scheduled (JDK 21 + toolchain ladder)
 
 - **Ticket:** F-018 → `todo` (inserted under P0 by user request: “Schedule JDK upgrade for the latest supported by AGP”)

--- a/docs/SAMPLE-APP.md
+++ b/docs/SAMPLE-APP.md
@@ -107,7 +107,7 @@ printf 'sdk.dir=%s\n' "$ANDROID_HOME" > application/local.properties
 cd application && ./gradlew build
 ```
 
-Toolchain: AGP **8.1.2**, compileSdk **34**, targetSdk **33**, Gradle **8.4**,
+Toolchain: AGP **8.1.2**, compileSdk **34**, targetSdk **33**, Gradle **8.7**,
 JDK **17**. See [ENV.md](ENV.md), [COMPOSE.md](COMPOSE.md), [ARCHITECTURE.md](ARCHITECTURE.md).
 
 ## What “gold standard” means here

--- a/examples/agent-skills/forma-compose.md
+++ b/examples/agent-skills/forma-compose.md
@@ -9,7 +9,7 @@ Doc: `docs/COMPOSE.md`. Example: `examples/android/06-compose`.
 
 ```kotlin
 // root
-androidProjectConfiguration(..., compose = true, composeCompilerVersion = "1.5.3")
+androidProjectConfiguration(..., compose = true, composeCompilerVersion = "1.5.10")
 
 impl(..., compose = true, dependencies = transitiveDeps("androidx.compose.ui:ui:…", /* … */))
 composeWidget(packageName = "…", dependencies = transitiveDeps(/* compose libs */))
@@ -18,5 +18,5 @@ androidBinary(..., compose = true, ...)
 
 - Forma enables `buildFeatures.compose` + compiler extension version
 - **You** still add Compose Maven artifacts
-- Align compiler version with Kotlin (sample: 1.5.3 ↔ 1.9.10)
+- Align compiler version with Kotlin (sample: 1.5.10 ↔ 1.9.22)
 - **`deps("gav")` is non-transitive** — use `transitiveDeps(...)` for Compose (same as `androidx.compose` in `build-dependencies/`)

--- a/examples/android/01-hello-apk/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/01-hello-apk/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/02-feature-api-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/02-feature-api-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/03-res-viewbinding/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/03-res-viewbinding/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/04-shared-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/04-shared-libs/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/05-widget-ui/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/05-widget-ui/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/06-compose/build.gradle.kts
+++ b/examples/android/06-compose/build.gradle.kts
@@ -6,6 +6,6 @@ buildscript {
         compileSdk = 34,
         agpVersion = "8.1.2",
         compose = true,
-        composeCompilerVersion = "1.5.3",
+        composeCompilerVersion = "1.5.10",
     )
 }

--- a/examples/android/06-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/06-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/07-multi-feature/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/07-multi-feature/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/08-deps-catalog/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/08-deps-catalog/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/09-test-utils/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/09-test-utils/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/01-hello-binary/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/01-hello-binary/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/02-api-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/02-api-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/03-library-util/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/03-library-util/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/04-multi-feature/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/04-multi-feature/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/05-test-util/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/05-test-util/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/includer/gradle/wrapper/gradle-wrapper.properties
+++ b/includer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/jvm-application/gradle/wrapper/gradle-wrapper.properties
+++ b/jvm-application/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.4-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugins/android/src/main/java/androidProjectConfiguration.kt
+++ b/plugins/android/src/main/java/androidProjectConfiguration.kt
@@ -121,8 +121,8 @@ fun Project.androidProjectConfiguration(
     registerAndroidDefaults()
 }
 
-/** Compose Compiler matching Kotlin 1.9.10 (application Gradle 8.4 embedded Kotlin). */
-const val DEFAULT_COMPOSE_COMPILER_VERSION = "1.5.3"
+/** Compose Compiler matching Kotlin 1.9.22 (Gradle 8.7 embedded Kotlin). */
+const val DEFAULT_COMPOSE_COMPILER_VERSION = "1.5.10"
 
 val buildScriptConfiguration: ScriptHandlerScope.(List<Any>) -> Unit = { classpathDeps ->
     // TODO pass repositories configuration

--- a/plugins/config/src/main/java/tools/forma/config/AndroidProjectSettings.kt
+++ b/plugins/config/src/main/java/tools/forma/config/AndroidProjectSettings.kt
@@ -40,7 +40,7 @@ data class AndroidProjectSettings(
      * Jetpack Compose compiler extension version applied when a target enables
      * Compose (`composeOptions.kotlinCompilerExtensionVersion`). Must match the
      * Kotlin version used by the project (see Compose Compiler compatibility map).
-     * Default `1.5.3` pairs with Kotlin **1.9.10** (Gradle 8.4 embedded Kotlin used
+     * Default `1.5.10` pairs with Kotlin **1.9.22** (Gradle 8.7 embedded Kotlin used
      * by the sample application). Override when bumping Kotlin.
      */
     val composeCompilerVersion: String,

--- a/plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.3-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-8.7-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME


### PR DESCRIPTION
## Summary
- **Phase 1 of F-018:** every Gradle wrapper → **8.7** (plugins, application, includer, depgen, jvm-application, bazel-adapter, examples, build-*, root)
- Companion fixes required by embedded Kotlin **1.9.22**:
  - force `kotlin-stdlib{,-jdk7,-jdk8,-common}` + `kotlin-reflect` under `failOnVersionConflict`
  - KSP **1.9.22-1.0.16** (1.0.18 caused kapt↔ksp circular tasks)
  - Compose compiler default **1.5.10**

## Why this was late
Jul 12 produced a plan + priority buttons instead of implementing; F-018 was not on `TICKETS.md` until today, so workers shipped other tickets. This PR is the actual upgrade.

## Verify (host)
- `plugins/ ./gradlew --version` → 8.7
- `plugins/ ./gradlew build` → BUILD SUCCESSFUL
- `application/ ./gradlew build` → BUILD SUCCESSFUL (2203 tasks)
- includer / depgen / bazel-adapter / jvm-application → BUILD SUCCESSFUL

## Still open on F-018
- Host/CI JDK 21
- AGP 8.5.2 → 8.7 → 8.13 ladder