### PR TITLE
F-070: revise plugins design (static register / custom type)

### DIFF
--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ systems like Buck and Bazel.
 2. [**JVM getting started**](docs/JVM-GETTING-STARTED.md) — pure JVM tutorial, run the sample, greenfield skeleton with `binary`, `api`/`impl`, target cheat sheet (F-032)
 3. [Sample app gold standard](docs/SAMPLE-APP.md) — multi-feature layout to copy
 4. [Dependency matrix](docs/DEPENDENCY-MATRIX.md) — what may depend on what
-5. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins API design](docs/TARGET-PLUGINS.md) (F-070: static register / custom type + `pluginConfig`) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
+5. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins API design](docs/TARGET-PLUGINS.md) (F-070: Bazel-like type-owned plugins) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
 6. [Plugin publish path](docs/PLUGIN-PUBLISH.md) — Portal metadata DSL + release notes (F-016)
 7. [Configuration performance](docs/CONFIGURATION-PERFORMANCE.md) — measure + hot-path guidance (F-017 / GH #106)
 8. [forma-core public API design](docs/forma-core-api.md) — extraction contract for types / restrictions / registry (F-020)

--- a/README.md
+++ b/README.md
@@ -45,7 +45,7 @@ systems like Buck and Bazel.
 2. [**JVM getting started**](docs/JVM-GETTING-STARTED.md) — pure JVM tutorial, run the sample, greenfield skeleton with `binary`, `api`/`impl`, target cheat sheet (F-032)
 3. [Sample app gold standard](docs/SAMPLE-APP.md) — multi-feature layout to copy
 4. [Dependency matrix](docs/DEPENDENCY-MATRIX.md) — what may depend on what
-5. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins API design](docs/TARGET-PLUGINS.md) (F-070) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
+5. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins API design](docs/TARGET-PLUGINS.md) (F-070: static register / custom type + `pluginConfig`) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
 6. [Plugin publish path](docs/PLUGIN-PUBLISH.md) — Portal metadata DSL + release notes (F-016)
 7. [Configuration performance](docs/CONFIGURATION-PERFORMANCE.md) — measure + hot-path guidance (F-017 / GH #106)
 8. [forma-core public API design](docs/forma-core-api.md) — extraction contract for types / restrictions / registry (F-020)

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -74,18 +74,18 @@ encourages dumping mixed concerns into one bucket. Prefer specific targets.
 
 ## P7 — Target plugins API (uniform external plugins)
 
-Replace chain-based `TargetBuilder.withPlugin` / `PluginWrapper` with:
-**static plugin registration** (pre-defined types) or **plugin on custom target
-type**, plus a uniform optional **`pluginConfig`** on target definitions.
-Design: `docs/TARGET-PLUGINS.md`. Closes the product gap behind GH #36.
-**Not** free-form plugin id lists on every target.
+Replace chain-based `TargetBuilder.withPlugin` / `PluginWrapper` with a
+**Bazel-like** model: plugin identity on the **target type** (static extend of
+pre-defined types **or** derived custom type); call sites are attributes-only and
+**auto-apply** type plugins. Design: `docs/TARGET-PLUGINS.md`. GH #36.
+**Not** free-form plugin ids or per-callsite `pluginConfig(binding)`.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-070 | done | Design uniform target plugins API + deprecation plan | `docs/TARGET-PLUGINS.md` **revised**: Path A static `registerTargetPlugin` + optional `pluginConfig` on pre-defined types; Path B plugin identity on **custom target type** + same config arg. **Rejected** free-form `plugins = plugins(plugin(id)…)` lists. Deprecate chain `withPlugin` |
-| F-071 | todo | Implement `PluginBinding` / `registerTargetPlugin` / `TargetPluginConfig` + wire `pluginConfig` on all Android/JVM pre-defined DSLs | No raw plugin ids on targets; unit tests; shims keep sample green |
-| F-072 | todo | Custom target types with type-owned plugins; migrate sample; deprecate `TargetBuilder` / `PluginWrapper` | safe-args ± binary; Path A and/or B |
-| F-073 | todo | Docs + progressive example + agent skill; close GH #36 | Document Paths A/B only |
+| F-070 | done | Design uniform target plugins API + deprecation plan | `docs/TARGET-PLUGINS.md` — Bazel north star; type owns plugin; call sites auto-apply; config = rule attrs / type-associated config only. Rejected free-form lists **and** call-site binding re-selection |
+| F-071 | todo | Type→plugin registry + auto-apply in DSLs; `targetPlugin` / `deriveTargetType` hooks | No call-site plugin ids; unit tests prove auto-apply |
+| F-072 | todo | Path B sample migration (e.g. `navigationRes`); deprecate `TargetBuilder` / `PluginWrapper` | Bazel-flat call sites; zero `.withPlugin` |
+| F-073 | todo | Docs + progressive example + agent skill; close GH #36 | §3 Bazel mapping in user docs |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -74,16 +74,18 @@ encourages dumping mixed concerns into one bucket. Prefer specific targets.
 
 ## P7 — Target plugins API (uniform external plugins)
 
-Replace chain-based `TargetBuilder.withPlugin` / `PluginWrapper` with a **single
-`plugins` argument on every target definition**. Design: `docs/TARGET-PLUGINS.md`.
-Closes the product gap behind GH #36.
+Replace chain-based `TargetBuilder.withPlugin` / `PluginWrapper` with:
+**static plugin registration** (pre-defined types) or **plugin on custom target
+type**, plus a uniform optional **`pluginConfig`** on target definitions.
+Design: `docs/TARGET-PLUGINS.md`. Closes the product gap behind GH #36.
+**Not** free-form plugin id lists on every target.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-070 | done | Design uniform target plugins API + deprecation plan | `docs/TARGET-PLUGINS.md` — Mode 1/2/3 model; `TargetPlugins` / `plugin()`; deprecate chain API; no separate target types by default |
-| F-071 | todo | Implement `TargetPlugins` + wire `plugins` on all Android/JVM target DSLs | `applyTargetPlugins` after features; unit tests; shims keep sample green |
-| F-072 | todo | Migrate sample off `withPlugin`; deprecate `TargetBuilder` / `PluginWrapper` | `Plugins.kt` → `PluginSpec` recipes; binary/safe-args call sites |
-| F-073 | todo | Docs + progressive example + agent skill; close GH #36 | GETTING-STARTED + DEPS-CATALOG Mode 2 vs 3; ladder step |
+| F-070 | done | Design uniform target plugins API + deprecation plan | `docs/TARGET-PLUGINS.md` **revised**: Path A static `registerTargetPlugin` + optional `pluginConfig` on pre-defined types; Path B plugin identity on **custom target type** + same config arg. **Rejected** free-form `plugins = plugins(plugin(id)…)` lists. Deprecate chain `withPlugin` |
+| F-071 | todo | Implement `PluginBinding` / `registerTargetPlugin` / `TargetPluginConfig` + wire `pluginConfig` on all Android/JVM pre-defined DSLs | No raw plugin ids on targets; unit tests; shims keep sample green |
+| F-072 | todo | Custom target types with type-owned plugins; migrate sample; deprecate `TargetBuilder` / `PluginWrapper` | safe-args ± binary; Path A and/or B |
+| F-073 | todo | Docs + progressive example + agent skill; close GH #36 | Document Paths A/B only |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/DEPS-CATALOG.md
+++ b/docs/DEPS-CATALOG.md
@@ -146,5 +146,5 @@ for the androidx/google surface used across features.
 - Architecture map: [`ARCHITECTURE.md`](ARCHITECTURE.md) §2.4
 - Sample settings: `application/settings.gradle.kts`
 - Sample typed catalogs: `build-dependencies/dependencies/src/main/kotlin/`
-- **Target-declared plugins** (safe-args, Crashlytics, …) are a separate mode from
-  catalog companion-lib apply — design: [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) (F-070+)
+- **Target external plugins** — static registration or custom target type + optional
+  `pluginConfig` (not free-form id lists): [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) (F-070+)

--- a/docs/DEPS-CATALOG.md
+++ b/docs/DEPS-CATALOG.md
@@ -146,5 +146,5 @@ for the androidx/google surface used across features.
 - Architecture map: [`ARCHITECTURE.md`](ARCHITECTURE.md) §2.4
 - Sample settings: `application/settings.gradle.kts`
 - Sample typed catalogs: `build-dependencies/dependencies/src/main/kotlin/`
-- **Target external plugins** — static registration or custom target type + optional
-  `pluginConfig` (not free-form id lists): [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) (F-070+)
+- **Target external plugins** — type owns plugin, call sites auto-apply (Bazel-like):
+  [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) (F-070+)

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,23 +2,31 @@
 
 Newest entries first.
 
+## 2026-07-19 — F-070 revised again: Bazel-like call sites
+
+- **Ticket:** F-070 design correction (PR #185 update)
+- **User correction:** first Path A example was wrong — extending a target type with a plugin must **auto-apply on every call site**; config should look almost like **Bazel** in Gradle files. No per-callsite `pluginConfig(binding)`.
+- **Model:**
+  - Type/rule owns plugin identity
+  - Call sites = attributes only (`navigationRes(packageName=…, dependencies=…)`)
+  - Path A = static extend pre-defined type (global for that type)
+  - Path B = derived type (preferred when only some modules need the plugin)
+  - Complex config = rule attrs or one type-associated config arg — never plugin ids
+- **Docs:** rewrite [`docs/TARGET-PLUGINS.md`](TARGET-PLUGINS.md)
+- **Next:** F-071 type→plugin registry + auto-apply
+
 ## 2026-07-19 — F-070 revised: reject free-form plugins lists
 
 - **Ticket:** F-070 remains `done` (design corrected); F-071…F-073 notes updated
 - **User correction:** free-form `plugins = plugins(plugin("id")…)` on every target is **exactly what to avoid**
-- **Correct model:**
-  - **Path A** — pre-defined types: **static** `registerTargetPlugin` → optional uniform **`pluginConfig`** on target def
-  - **Path B** — **custom target type** owns plugin identity → same optional **`pluginConfig`**
-- **Docs:** full rewrite of [`docs/TARGET-PLUGINS.md`](TARGET-PLUGINS.md); TICKETS P7 notes aligned
+- **Note:** intermediate draft still had call-site binding selection — superseded by Bazel auto-apply revision above
 - **Product code:** none
-- **Next:** F-071 implement registration + `pluginConfig` wiring
 
 ## 2026-07-19 — F-070: target plugins API design
 
 - **Ticket:** F-070 → `done` (design only); **F-071…F-073** `todo` on board (P7)
-- **User ask:** design proper APIs for plugins support; deprecate existing mechanism; uniform plugin configs per target definition
-- **Branch / PR:** #184 → `v2` (initial write; **superseded by revision** — see entry above)
-- **Note:** first draft incorrectly proposed free-form `plugins =` lists; corrected after user feedback
+- **Branch / PR:** #184 → `v2` (initial write; superseded)
+- **Note:** first draft free-form `plugins =` lists — wrong
 - **Product code:** none this slice
 - **Blockers:** none
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,21 +2,24 @@
 
 Newest entries first.
 
+## 2026-07-19 — F-070 revised: reject free-form plugins lists
+
+- **Ticket:** F-070 remains `done` (design corrected); F-071…F-073 notes updated
+- **User correction:** free-form `plugins = plugins(plugin("id")…)` on every target is **exactly what to avoid**
+- **Correct model:**
+  - **Path A** — pre-defined types: **static** `registerTargetPlugin` → optional uniform **`pluginConfig`** on target def
+  - **Path B** — **custom target type** owns plugin identity → same optional **`pluginConfig`**
+- **Docs:** full rewrite of [`docs/TARGET-PLUGINS.md`](TARGET-PLUGINS.md); TICKETS P7 notes aligned
+- **Product code:** none
+- **Next:** F-071 implement registration + `pluginConfig` wiring
+
 ## 2026-07-19 — F-070: target plugins API design
 
 - **Ticket:** F-070 → `done` (design only); **F-071…F-073** `todo` on board (P7)
-- **User ask:** design proper APIs for plugins support; deprecate existing mechanism; uniform plugin configs per target definition; simple = part of target def; complex = single arg config (prefer over new target types)
-- **Branch / PR:** `forma/F-070-target-plugins-design` → base `v2`
-- **Skills/modes:** Hermes design/docs (no Grok Build product coding this slice)
-- **Design:** [`docs/TARGET-PLUGINS.md`](TARGET-PLUGINS.md)
-  - **Mode 1** platform features (`FeatureDefinition`) — unchanged
-  - **Mode 2** catalog dependency-driven plugins (KSP) — unchanged; see DEPS-CATALOG
-  - **Mode 3** target-declared `plugins: TargetPlugins` on **every** target DSL
-  - Deprecate `TargetBuilder.withPlugin` / `withPlugins` + public `PluginWrapper` UX
-  - Complex config stays one arg: `plugin(id) { Extension.… }` + optional deps
-  - Separate target type only when plugin creates a new *role* (not for safe-args/Crashlytics)
+- **User ask:** design proper APIs for plugins support; deprecate existing mechanism; uniform plugin configs per target definition
+- **Branch / PR:** #184 → `v2` (initial write; **superseded by revision** — see entry above)
+- **Note:** first draft incorrectly proposed free-form `plugins =` lists; corrected after user feedback
 - **Product code:** none this slice
-- **Next:** F-071 implement + wire DSLs
 - **Blockers:** none
 
 ## 2026-07-19 — F-018 close: docs soak + ticket done

--- a/docs/TARGET-PLUGINS.md
+++ b/docs/TARGET-PLUGINS.md
@@ -1,316 +1,372 @@
 # Target plugins API design (F-070)
 
-Design contract for **uniform external Gradle plugin support on Forma
-targets**. Grounded in live code under `plugins/android` + `plugins/deps`, the
-sample `application/`, and open GH **#36** (docs for external plugins).
+Design contract for **external Gradle plugin support on Forma targets**.
 
-**Status:** accepted design (this document). **Implementation:** F-071…F-073.
+**Status:** accepted design (revised). Prior free-form `plugins = plugins(…)`
+list-on-every-target sketch is **rejected** (see §10).
 
-**Related:** [`DEPS-CATALOG.md`](DEPS-CATALOG.md) (settings `plugin()` +
-dependency-driven apply), [`ARCHITECTURE.md`](ARCHITECTURE.md),
-[`forma-core-api.md`](forma-core-api.md).
+**Implementation:** F-071…F-073.
+
+**Related:** [`DEPS-CATALOG.md`](DEPS-CATALOG.md), [`ARCHITECTURE.md`](ARCHITECTURE.md),
+[`forma-core-api.md`](forma-core-api.md), `TargetRegistry` / `TargetRegistration`.
 
 ---
 
 ## 1. Problem
 
-Today external plugins are bolted on through **three overlapping paths**:
+Today external plugins are bolted on via **chain API**:
 
-| Path | Where | Used for |
-|------|--------|----------|
-| **A. Chain API** | `TargetBuilder.withPlugin` / `withPlugins` + `PluginWrapper` | Safe-args on `androidRes`; commented Crashlytics/Google Services on `androidBinary` |
-| **B. Dependency-driven** | Catalog `plugin(…, configuration, companionLibs)` + `applyDependencies` | KSP when a target depends on a processor registered with `CustomConfiguration("ksp")` |
-| **C. Built-in features** | `FeatureDefinition` / `applyFeatures` | AGP, Kotlin Android, kapt-on-demand, Compose compiler |
+```kotlin
+androidRes(…).withPlugin(Plugins.navigationSafeArgs)
+// androidBinary(…).withPlugins(Plugins.googleServices, Plugins.crashlytics())
+```
 
-Path **A** is the user-facing “external plugins” story and is broken as a product API:
+Issues:
 
-1. **Not uniform.** Only some DSLs return `TargetBuilder`
-   (`androidRes`, `uiLibrary`, `androidBinary`). `impl`, `api`, `widget`,
-   `androidApp`, JVM targets, etc. return `Unit` — no chain, no plugins.
-2. **Not part of the target definition.** Plugins are a post-hoc
-   `.withPlugin(…)` after the target call, so configuration is split across
-   two syntactic sites and easy to miss in reviews/examples.
-3. **`PluginWrapper` is a second mini-DSL** (id + deps + typed extension)
-   living in sample `build-dependencies` (`Plugins.kt`) rather than a first-class
-   Forma target parameter.
-4. **Docs never shipped** (GH #36) because there is no single story to document.
-5. Paths **B** and **C** are the right *mechanisms* for their jobs; they must
-   stay, but **must not** be confused with explicit target plugins.
+1. **Plugin identity is chosen ad hoc at each module** (`PluginWrapper` + raw
+   plugin ids) — not tied to target *types* or a registration surface.
+2. **Not uniform** — only some DSLs return `TargetBuilder`.
+3. **Split definition** — target call vs `.withPlugin` chain.
+4. **No custom-target story** — can’t say “this target *kind* always carries
+   plugin X; instances only pass config.”
+5. GH **#36** (docs) never closed because the product API was wrong.
+
+Catalog dependency-driven apply (KSP) and internal `FeatureDefinition` (AGP /
+Kotlin / Compose) stay separate — they are not this design.
 
 ---
 
-## 2. Goals and non-goals
+## 2. Design principle (product intent)
+
+> **Plugin identity is not a free-form list on every target call.**
+
+Two supported ways to attach an external Gradle plugin:
+
+| Path | When | Where plugin id lives | What the target definition takes |
+|------|------|------------------------|-----------------------------------|
+| **A. Static registration** | Using **pre-defined** target types (`impl`, `api`, `androidRes`, `androidBinary`, …) | **Static registration API** (settings / platform bootstrap) | Optional **plugin config** only (uniform shape) |
+| **B. Custom target type** | Plugin defines a reusable *kind* of module | **On the target type** registration | Same optional **plugin config** arg |
+
+**Not supported as the product API:**
+
+```kotlin
+// REJECTED — free-form plugin shopping list on every module
+androidRes(..., plugins = plugins(plugin("some.id"), plugin("other.id")))
+```
+
+That reintroduces unstructured Gradle habits Forma exists to remove.
+
+---
+
+## 3. Goals and non-goals
 
 ### Goals
 
-1. **One uniform plugins argument** on every Forma target definition
-   (Android + JVM), same shape everywhere.
-2. **Simple cases** express plugins **inside** the target call (no chain).
-3. **Complex cases** use the **same single argument** with richer
-   `PluginSpec` values (typed extension config + optional companion deps) —
-   **not** a new target type by default.
-4. **Deprecate** `TargetBuilder.withPlugin` / `withPlugins` and the
-   chain-return pattern as the supported plugins UX.
-5. Keep **dependency-driven** catalog plugins (KSP/processors) and
-   **built-in features** (AGP/Kotlin/Compose) as separate, documented modes.
-6. Preserve type-safe extension configuration where Gradle extensions exist
-   (today’s `pluginConfiguration<CrashlyticsExtension> { … }` capability).
+1. **Deprecate** `TargetBuilder.withPlugin` / `withPlugins` and public
+   `PluginWrapper` as the consumer UX.
+2. **Static API** to register external plugins for use with **pre-defined**
+   target types (handles / bindings — not raw id soup at each callsite).
+3. **Custom target types** declare **plugin (identity) on the type**; instances
+   pass optional **config**.
+4. **Uniform plugin config** model for the per-target-definition argument
+   (simple: omit or empty; complex: single config arg — not a second chain API).
+5. Keep Mode “catalog / KSP” and Mode “platform features” unchanged and documented
+   as different concerns.
 
 ### Non-goals
 
 | Concern | Decision |
 |---------|----------|
-| New target types per popular plugin (e.g. `safeArgsRes`) | **Out** unless the plugin changes the *role* of the module enough to deserve a `TargetType` (see §6) |
-| Replacing `FeatureDefinition` for AGP/Kotlin | **Out** — platform features stay internal |
-| Replacing catalog `plugin()` + companion-lib apply | **Out** — path B stays for processor-style plugins |
-| Plugin Portal / classpath resolution redesign | **Out** — consumers still put plugin markers on `buildscript` / `pluginManagement` as today |
-| Arbitrary multi-step configuration builders beyond one plugins arg | **Out** for v1 — prefer recipes in shared modules |
+| Arbitrary multi-plugin lists on every built-in DSL | **Rejected** |
+| Replacing `FeatureDefinition` for AGP/Kotlin/Compose | Out of scope |
+| Replacing catalog `plugin()` + companion-lib apply | Out of scope |
+| Plugin classpath / Portal resolution redesign | Out of scope |
+| One new built-in DSL per popular plugin (`safeArgsRes` as forever core) | Prefer **custom type** in the consumer graph, or static binding + config |
 
 ---
 
-## 3. Conceptual model — three plugin modes
-
-Document and implement these as **distinct modes**:
+## 4. Conceptual model
 
 ```
-┌─────────────────────────────────────────────────────────────┐
-│ Mode 1 — Platform features (internal)                       │
-│   applyFeatures(AGP, kotlin-android, compose compiler, …)   │
-│   Not user-facing “plugins = …”                             │
-└─────────────────────────────────────────────────────────────┘
-┌─────────────────────────────────────────────────────────────┐
-│ Mode 2 — Dependency-driven (catalog)                        │
-│   settings: plugin(id, version, CustomConfiguration, libs)  │
-│   target: dependencies = deps(libs.roomCompiler)            │
-│   → apply plugin + wire config when dep is consumed         │
-│   See DEPS-CATALOG.md                                       │
-└─────────────────────────────────────────────────────────────┘
-┌─────────────────────────────────────────────────────────────┐
-│ Mode 3 — Target-declared plugins (THIS DESIGN)              │
-│   target(…, plugins = plugins(…))                           │
-│   Explicit apply + optional extension config + optional deps│
-│   Safe-args, Google Services, Crashlytics, detekt, …        │
-└─────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ Platform features (internal)                                         │
+│   FeatureDefinition — AGP, kotlin-android, compose compiler, …       │
+└──────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ Dependency-driven (catalog)                                          │
+│   settings plugin(id, CustomConfiguration, companion libs)           │
+│   → apply when target depends on companion artifact (KSP, …)         │
+└──────────────────────────────────────────────────────────────────────┘
+┌──────────────────────────────────────────────────────────────────────┐
+│ External plugins (THIS DESIGN)                                       │
+│                                                                      │
+│  Path A — pre-defined types                                          │
+│    static register(PluginBinding) → optional pluginConfig on target  │
+│                                                                      │
+│  Path B — custom target type                                         │
+│    register type + plugin identity → optional pluginConfig on target │
+└──────────────────────────────────────────────────────────────────────┘
 ```
 
-**Rule of thumb for authors**
-
-| Situation | Mode |
-|-----------|------|
-| Always-on platform capability for this target kind | Mode 1 (Forma owns it) |
-| “If I depend on this artifact, apply its plugin” | Mode 2 (catalog) |
-| “This module needs plugin X regardless of a single lib” | Mode 3 (target `plugins`) |
+**Invariant:** at a target *call site*, consumers configure plugins only through
+a **uniform optional config argument** (and/or a registered binding reference).
+They do not pass open-ended lists of plugin ids.
 
 ---
 
-## 4. Proposed public API
+## 5. Path A — Static registration (pre-defined target types)
 
-### 4.1 Single argument on every target
+### 5.1 Registration API (settings / root / platform config time)
 
-Every user-facing target DSL gains:
+Register plugin bindings once. Registration creates a **typed handle** the rest
+of the build refers to — plugin id, optional default companion deps, optional
+allowed pre-defined target types, optional extension type.
 
 ```kotlin
-plugins: TargetPlugins = emptyPlugins()
+// Conceptual public API (names flexible in F-071)
+
+interface PluginBinding<E : Any = Any> {
+    val id: String
+    // implementation details: extension KClass, default deps, allowed types
+}
+
+// Static registration — e.g. next to androidProjectConfiguration / settings
+fun <E : Any> registerTargetPlugin(
+    id: String,
+    extensionClass: KClass<E>? = null,
+    allowedTypes: Set<TargetType> = emptySet(), // empty = any pre-defined type that accepts config
+    dependencies: FormaDependency = emptyDependency(),
+): PluginBinding<E>
 ```
 
-**Examples — simple (id only)**
+**Sample registration (app or `build-dependencies`):**
 
 ```kotlin
-androidRes(
-    packageName = "tools.forma.sample.core.navigation.library",
-    dependencies = deps(androidx.navigation),
-    plugins = plugins(
-        "androidx.navigation.safeargs.kotlin",
-    ),
+val navigationSafeArgs = registerTargetPlugin(
+    id = "androidx.navigation.safeargs.kotlin",
+    allowedTypes = setOf(AndroidTargetTypes.res),
+)
+
+val googleServices = registerTargetPlugin(
+    id = "com.google.gms.google-services",
+    allowedTypes = setOf(AndroidTargetTypes.binary, AndroidTargetTypes.app),
+)
+
+val crashlytics = registerTargetPlugin(
+    id = "com.google.firebase.crashlytics",
+    extensionClass = CrashlyticsExtension::class,
+    allowedTypes = setOf(AndroidTargetTypes.binary),
+    dependencies = google.firebase,
 )
 ```
 
-**Examples — complex (typed config + companion deps) still one arg**
+Classpath / version resolution stays with existing `pluginManagement` /
+`buildscript` / catalog markers — registration does not replace that.
+
+### 5.2 Pre-defined target definition — optional config only
+
+Built-in DSLs gain a **uniform optional** argument for plugin configuration —
+not a vararg plugin id list.
 
 ```kotlin
+/**
+ * Uniform per-target plugin configuration.
+ *
+ * - [binding] — handle from [registerTargetPlugin] (required if any plugin apply is requested)
+ * - [configure] — optional extension configuration when the binding has an extension type
+ *
+ * Multiple plugins on one pre-defined module: prefer Path B (custom type that
+ * owns the plugin set), or a single composite binding if F-071 finds a clean shape.
+ * v1 may allow a small ordered list of [PluginUse] inside one config arg — still
+ * one parameter, still only registered bindings (no raw ids).
+ */
+class TargetPluginConfig private constructor(
+    val uses: List<PluginUse>,
+) {
+    companion object {
+        val None: TargetPluginConfig = TargetPluginConfig(emptyList())
+    }
+}
+
+class PluginUse internal constructor(
+    val binding: PluginBinding<*>,
+    val configure: (Any.() -> Unit)? = null,
+)
+
+fun pluginConfig(binding: PluginBinding<*>): TargetPluginConfig =
+    TargetPluginConfig(/* single use, no configure */)
+
+fun <E : Any> pluginConfig(
+    binding: PluginBinding<E>,
+    configure: E.() -> Unit,
+): TargetPluginConfig = …
+
+fun pluginConfig(vararg uses: PluginUse): TargetPluginConfig = …
+fun <E : Any> PluginBinding<E>.withConfig(configure: E.() -> Unit): PluginUse = …
+```
+
+**Call sites (pre-defined types):**
+
+```kotlin
+// Simple — registered binding, no extension config
+androidRes(
+    packageName = "tools.forma.sample.core.navigation.library",
+    dependencies = deps(androidx.navigation),
+    pluginConfig = pluginConfig(navigationSafeArgs),
+)
+
+// Complex — still one arg; registered bindings only (no raw ids)
 androidBinary(
     packageName = "tools.forma.sample.app",
     versionCode = 1,
     versionName = "0.0.1",
     dependencies = deps(/* … */),
-    plugins = plugins(
-        "com.google.gms.google-services",
-        plugin(
-            id = "com.google.firebase.crashlytics",
-            dependencies = google.firebase,
-        ) {
-            // CrashlyticsExtension receiver
+    pluginConfig = pluginConfig(
+        googleServices,
+        crashlytics.withConfig {
             mappingFileUploadEnabled = false
         },
     ),
 )
-```
+**Rules**
 
-**Shared recipes** (optional, still produce `PluginSpec` for the same arg):
+1. Only **registered** bindings — raw plugin id strings are not accepted on
+   target DSLs.
+2. If `allowedTypes` is non-empty, binding must be allowed for that target’s
+   `TargetType` or configuration fails fast.
+3. Apply order: platform features → target plugins from config → dependencies
+   (same as today’s need for AGP-before-safe-args).
+4. Default: `pluginConfig = TargetPluginConfig.None` (no external plugins).
 
-```kotlin
-// build-dependencies or app-owned module — not a second apply path
-object AppPlugins {
-    val navigationSafeArgs = plugin("androidx.navigation.safeargs.kotlin")
-    val googleServices = plugin("com.google.gms.google-services")
-    fun crashlytics(mappingFileUploadEnabled: Boolean = false) =
-        plugin("com.google.firebase.crashlytics", dependencies = google.firebase) {
-            this.mappingFileUploadEnabled = mappingFileUploadEnabled
-        }
-}
-
-androidBinary(
-    /* … */,
-    plugins = plugins(AppPlugins.googleServices, AppPlugins.crashlytics()),
-)
-```
-
-### 4.2 Types (plugins `:deps` or thin `:android` re-export)
-
-Package suggestion: `tools.forma.deps.core` (next to today’s `PluginWrapper`)
-with facades if needed.
-
-```kotlin
-/** Ordered list of external plugins to apply on a target. */
-class TargetPlugins internal constructor(
-    val specs: List<PluginSpec>,
-) {
-    companion object {
-        val Empty: TargetPlugins = TargetPlugins(emptyList())
-    }
-}
-
-fun emptyPlugins(): TargetPlugins = TargetPlugins.Empty
-
-fun plugins(vararg specs: PluginSpec): TargetPlugins =
-    TargetPlugins(specs.toList())
-
-/** Convenience: bare plugin ids. */
-fun plugins(vararg ids: String): TargetPlugins =
-    TargetPlugins(ids.map { PluginSpec(id = it) })
-
-/**
- * One external plugin application.
- *
- * @param id Gradle plugin id (already on classpath / pluginManagement)
- * @param dependencies optional deps applied with EmptyValidator (same as today)
- * @param configure optional extension configuration; null = apply only
- */
-class PluginSpec internal constructor(
-    val id: String,
-    val dependencies: FormaDependency = emptyDependency(),
-    val configure: ((Project) -> Unit)? = null,
-)
-
-/** Apply-only plugin. */
-fun plugin(id: String, dependencies: FormaDependency = emptyDependency()): PluginSpec =
-    PluginSpec(id = id, dependencies = dependencies)
-
-/**
- * Type-safe extension configuration.
- * Replaces pluginConfiguration + PluginWrapper construction.
- */
-inline fun <reified E : Any> plugin(
-    id: String,
-    dependencies: FormaDependency = emptyDependency(),
-    noinline configure: E.() -> Unit,
-): PluginSpec = PluginSpec(
-    id = id,
-    dependencies = dependencies,
-    configure = { project ->
-        configure(project.the(E::class))
-    },
-)
-```
-
-**Overload note:** `plugins("a", "b")` (strings) and `plugins(spec1, spec2)`
-must not collide awkwardly. Prefer:
-
-- `plugins(vararg specs: PluginSpec)` as the primary API
-- `plugin("id")` always returns `PluginSpec`
-- optional `plugins(ids: Iterable<String>)` if bare strings are desired without
-  `plugin()` wrappers
-
-Recommended call style in docs/examples:
-
-```kotlin
-plugins = plugins(
-    plugin("androidx.navigation.safeargs.kotlin"),
-)
-```
-
-Bare-string sugar is nice-to-have, not required for F-071.
-
-### 4.3 Apply semantics
-
-Internal helper (platform-agnostic enough for Android + JVM):
-
-```kotlin
-fun Project.applyTargetPlugins(plugins: TargetPlugins) {
-    val applied = linkedSetOf<String>()
-    for (spec in plugins.specs) {
-        check(applied.add(spec.id)) {
-            "Duplicate target plugin '${spec.id}' on project '$path'"
-        }
-        apply(plugin = spec.id)
-        spec.configure?.invoke(this)
-        if (spec.dependencies !== EmptyDependency) {
-            applyDependencies(
-                validator = EmptyValidator,
-                dependencies = spec.dependencies,
-                repositoriesConfiguration = EmptyRepositoriesConfiguration,
-            )
-        }
-    }
-}
-```
-
-**Ordering**
-
-1. Self-name / content validation  
-2. `applyFeatures` (Mode 1)  
-3. `applyTargetPlugins` (Mode 3)  
-4. `applyDependencies` (Mode 2 side effects + normal deps)
-
-Rationale: feature plugins establish the project kind; external plugins often
-expect AGP/Kotlin already applied (safe-args, Crashlytics).
-
-**Idempotency:** Mode 2 may also `apply(plugin = …)`. Use Gradle’s natural
-“already applied” behavior and/or a small per-project applied-id set shared
-with `applyDependencies` if double-apply proves noisy. Do **not** invent a
-global plugin registry in v1 beyond what’s needed for clear errors.
-
-### 4.4 DSL surface changes
-
-| Today | After F-071 |
-|-------|-------------|
-| `fun Project.impl(…): Unit` | `fun Project.impl(…, plugins: TargetPlugins = emptyPlugins())` |
-| `fun Project.androidRes(…): TargetBuilder` | `fun Project.androidRes(…, plugins: TargetPlugins = emptyPlugins())` — return type **Unit** (or deprecated `TargetBuilder` shim) |
-| Same for all Android + JVM targets | Same `plugins` param |
-
-**Return type policy**
-
-- Preferred end state: all target DSLs return **`Unit`**.
-- Migration: keep returning `@Deprecated TargetBuilder` that only supports
-  deprecated `withPlugin` forwarding to the same apply path for one minor
-  (0.1.x), then hard-remove in the next breaking window (aligned with other
-  DSL breaks).
+This is “static API for plugin registration” + “plugin config as part of target
+definition” for pre-defined types.
 
 ---
 
-## 5. Deprecation plan
+## 6. Path B — Custom target type + plugin on the type
 
-### 5.1 API to deprecate (F-072)
+When a plugin (or fixed plugin set) **defines a reusable module kind**, put
+plugin identity on the **type**, not on every instance.
 
-| Symbol | Replacement |
-|--------|-------------|
-| `TargetBuilder.withPlugin` | `plugins = plugins(…)` on the target |
+### 6.1 Type registration
+
+Extend registration beyond pure `TargetRegistration` (restriction/content) with
+optional Gradle plugin identity owned by the type:
+
+```kotlin
+// Conceptual — platform Gradle layer (not pure forma-core)
+
+data class CustomTargetType(
+    val registration: TargetRegistration, // type id, suffix, allow-list, content rules
+    /**
+     * Plugin(s) always applied for this kind.
+     * Identity lives here — instances do not re-state plugin ids.
+     */
+    val plugins: List<PluginBinding<*>> = emptyList(),
+    // optional: factory for default pluginConfig
+)
+
+// Consumer / platform helper
+fun registerCustomAndroidTarget(
+    id: String,
+    nameSuffix: String,
+    allowedDependencies: Set<TargetType>,
+    contentRules: List<ContentRule> = emptyList(),
+    plugins: List<PluginBinding<*>> = emptyList(),
+    // or single plugin: plugin: PluginBinding<*>? = null
+): CustomTargetType
+```
+
+**Example — navigation graphs kind:**
+
+```kotlin
+val navigationSafeArgs = registerTargetPlugin(
+    id = "androidx.navigation.safeargs.kotlin",
+)
+
+val navigationRes = registerCustomAndroidTarget(
+    id = "sample.navigation-res",
+    nameSuffix = "res", // or "navigation-res" if suffix isolation desired
+    allowedDependencies = setOf(
+        AndroidTargetTypes.res,
+        AndroidTargetTypes.widget,
+        AndroidTargetTypes.composeWidget,
+    ),
+    contentRules = listOf(OnlyResourcesUnderMain),
+    plugins = listOf(navigationSafeArgs),
+)
+```
+
+### 6.2 Instance definition — optional config only
+
+```kotlin
+// Generated or generic DSL — shape is what matters
+navigationRes(
+    packageName = "tools.forma.sample.core.navigation.library",
+    dependencies = deps(androidx.navigation),
+    // plugin id already on the type — only optional config:
+    pluginConfig = TargetPluginConfig.None,
+)
+
+// With extension config (single uniform arg)
+firebaseBinary(
+    packageName = "…",
+    versionCode = 1,
+    versionName = "0.0.1",
+    dependencies = deps(/* … */),
+    pluginConfig = pluginConfig(
+        crashlytics.withConfig { mappingFileUploadEnabled = false },
+    ),
+)
+```
+
+**Apply semantics for Path B**
+
+1. Validate self-type / content from `TargetRegistration`.
+2. Apply platform features for the base kind (library vs binary vs …).
+3. Apply **type-owned** plugins (always).
+4. Apply **instance** `pluginConfig` (extra bindings only if the type allows
+   overrides; v1 can restrict instance config to configuring type-owned
+   plugins’ extensions — simplest and clearest).
+5. `applyDependencies`.
+
+**Recommendation for v1 instance config on Path B:** `pluginConfig` only
+**configures** plugins already declared on the type (extension lambdas keyed by
+binding). It does **not** add new plugin ids. That keeps type = identity,
+instance = config.
+
+---
+
+## 7. Uniform `pluginConfig` argument
+
+Across **all** pre-defined DSLs and custom-target entrypoints:
+
+```kotlin
+pluginConfig: TargetPluginConfig = TargetPluginConfig.None
+```
+
+| Case | Shape |
+|------|--------|
+| No external plugin | omit / `None` |
+| Simple (apply registered / type-owned plugin, no extension knobs) | `pluginConfig = pluginConfig(binding)` or type-owned with `None` |
+| Complex extension settings | **single** `pluginConfig = pluginConfig(binding.withConfig { … })` |
+| Complex *kind* (different role or permanent plugin set) | **Path B** custom target type |
+
+No `.withPlugin` chain. No second structural style.
+
+---
+
+## 8. Deprecation plan
+
+| Remove / deprecate | Replacement |
+|--------------------|-------------|
+| `TargetBuilder.withPlugin` | Path A `pluginConfig` or Path B custom type |
 | `TargetBuilder.withPlugins` | same |
-| Public construction of `PluginWrapper` | `plugin(…)` / `PluginSpec` |
-| `pluginConfiguration { }` as user API | folded into `plugin(id) { }` |
-| Sample `Plugins.kt` using `PluginWrapper` | rewrite to `PluginSpec` recipes |
+| Public `PluginWrapper` / sample `Plugins.kt` wrappers as apply API | `registerTargetPlugin` + bindings |
+| `pluginConfiguration { }` user construction | `binding.withConfig { }` inside `pluginConfig` |
+| Returning `TargetBuilder` solely for chaining | Return `Unit`; temporary deprecated shim OK for one minor |
 
-### 5.2 Migration map (sample)
+**Sample migration**
 
 ```kotlin
 // BEFORE
@@ -319,12 +375,17 @@ androidRes(
     dependencies = deps(androidx.navigation),
 ).withPlugin(Plugins.navigationSafeArgs)
 
-// AFTER
+// AFTER — Path A
 androidRes(
     packageName = "…",
     dependencies = deps(androidx.navigation),
-    plugins = plugins(plugin("androidx.navigation.safeargs.kotlin")),
-    // or plugins(AppPlugins.navigationSafeArgs)
+    pluginConfig = pluginConfig(navigationSafeArgs), // registered handle
+)
+
+// AFTER — Path B (preferred if every navigation res always needs safe-args)
+navigationRes(
+    packageName = "…",
+    dependencies = deps(androidx.navigation),
 )
 ```
 
@@ -333,80 +394,23 @@ androidRes(
 androidBinary(… )
     .withPlugins(Plugins.googleServices, Plugins.crashlytics())
 
-// AFTER
+// AFTER — Path A with single config arg
 androidBinary(
     …,
-    plugins = plugins(
-        plugin("com.google.gms.google-services"),
-        plugin("com.google.firebase.crashlytics", dependencies = google.firebase) {
-            mappingFileUploadEnabled = false
-        },
+    pluginConfig = pluginConfig(
+        googleServices,
+        crashlytics.withConfig { mappingFileUploadEnabled = false },
+    ),
+)
+
+// AFTER — Path B if this binary kind is always “firebase app binary”
+firebaseBinary(
+    …,
+    pluginConfig = pluginConfig(
+        crashlytics.withConfig { mappingFileUploadEnabled = false },
     ),
 )
 ```
-
-### 5.3 Compatibility shims
-
-```kotlin
-@Deprecated(
-    message = "Pass plugins = plugins(…) on the target definition instead",
-    replaceWith = ReplaceWith("/* move PluginWrapper into target plugins = */"),
-)
-class TargetBuilder(/* … */) {
-    @Deprecated("…")
-    fun withPlugin(pluginWrapper: PluginWrapper<*>): TargetBuilder { /* apply */ }
-}
-```
-
-Convert `PluginWrapper` → internal adapter that builds `PluginSpec` once, or
-mark `PluginWrapper` itself `@Deprecated` and implement `invoke` via
-`applyTargetPlugins`.
-
----
-
-## 6. When (not) to add a separate target type
-
-User guidance: **prefer single-arg config**. Separate `TargetType` only if:
-
-1. The plugin **changes the role / content rules / dependency matrix** of the
-   module (new suffix, new allow-list), **and**
-2. That role is common enough to teach in the progressive ladder, **and**
-3. A boolean/plugins arg would **lie** about what the module is.
-
-Examples:
-
-| Case | Decision |
-|------|----------|
-| Navigation safe-args on a res module | **plugins arg** on `androidRes` |
-| Crashlytics on binary | **plugins arg** on `androidBinary` |
-| Detekt / Spotless on any module | **plugins arg** (or root convention — not Forma target type) |
-| Hypothetical “proto codegen library” with unique deps matrix | **consider new target type** in a later ticket |
-
-Do **not** mint `safeArgsAndroidRes` etc. in F-071–F-073.
-
----
-
-## 7. Relationship to forma-core
-
-- `TargetPlugins` / `PluginSpec` are **Gradle-facing** (need `Project.apply`,
-  extensions). They live in **`:deps`** (or platform plugins), **not** in pure
-  `tools.forma:core`.
-- Core remains free of AGP and of “which Google plugin ids exist.”
-- Bazel adapter does not need Mode 3 parity in v1; document as Gradle-only.
-
----
-
-## 8. Docs and examples (F-073 / closes GH #36)
-
-Ship as part of implementation, not a separate everlasting backlog item:
-
-1. This design → short user guide section in `GETTING-STARTED.md` + dedicated
-   “External plugins” page (can rename/trim this file to user voice once
-   implemented).
-2. `DEPS-CATALOG.md` — explicit “Mode 2 vs Mode 3” cross-link.
-3. Progressive example step (Android ladder) showing safe-args via `plugins =`.
-4. Agent skill blurb under `examples/agent-skills/`.
-5. Close GH **#36** when user docs land on `v2`.
 
 ---
 
@@ -414,10 +418,10 @@ Ship as part of implementation, not a separate everlasting backlog item:
 
 | ID | Scope | Acceptance |
 |----|--------|------------|
-| **F-070** | This design doc + tickets | Merged on `v2`; no product code required |
-| **F-071** | `TargetPlugins` / `PluginSpec` / `plugin()` / `applyTargetPlugins`; add `plugins` param to **all** Android + JVM target DSLs; apply after features | `plugins/` build green; unit tests for duplicate-id + empty path; sample still builds (may still use shim) |
-| **F-072** | Migrate sample + `Plugins.kt` to new API; `@Deprecated` on `TargetBuilder` / `PluginWrapper` chain; binary Crashlytics TODO becomes real `plugins =` **or** stays commented but in new shape | `application/` green; no `.withPlugin` call sites in tree except tests for deprecation if any |
-| **F-073** | User docs + progressive example + agent skill; close GH #36 | Docs-only PR ok if code already on `v2` |
+| **F-070** | This design (revised) | Merged on `v2` |
+| **F-071** | `PluginBinding`, `registerTargetPlugin`, `TargetPluginConfig`, `applyTargetPluginConfig`; wire **optional `pluginConfig`** on all Android/JVM pre-defined DSLs; reject raw plugin ids | unit tests; plugins build green |
+| **F-072** | Custom target type registration with type-owned plugins + instance config; migrate sample (safe-args ± binary); deprecate `TargetBuilder` / `PluginWrapper` | application green; no `.withPlugin` call sites |
+| **F-073** | User docs + progressive example + agent skill; close GH #36 | docs match Paths A/B only |
 
 ---
 
@@ -425,31 +429,48 @@ Ship as part of implementation, not a separate everlasting backlog item:
 
 | Alternative | Why rejected |
 |-------------|--------------|
-| Keep chain-only, return `TargetBuilder` from every DSL | Still splits definition; teaches a builder pattern Forma otherwise avoids |
-| Plugins only via catalog Mode 2 | Safe-args / Google Services are not “consume this one lib” |
-| Separate target type per plugin | Explodes the matrix; fights flat role model |
-| Multi-arg `plugin1=`, `plugin2=` or free lambda `plugins { }` block on Project | Harder to share recipes; single `TargetPlugins` value is copyable and testable |
-| Configure plugins only in `androidProjectConfiguration` | Wrong scope — plugins are per-module |
+| **Free-form `plugins = plugins(plugin("id"), …)` on every target** | Exactly the unstructured surface this work should avoid; plugin identity belongs on **registration** or **custom type** |
+| Keep chain-only `TargetBuilder` | Split definition; inconsistent return types |
+| Plugins only via catalog companion libs | Safe-args / GMS are not “consume this one library” |
+| New core built-in DSL per plugin (`safeArgsAndroidRes`) | Explodes platform surface; Path B custom types cover consumer graphs |
+| Multi-arg `safeArgs=`, `crashlytics=` booleans on every DSL | Not uniform; doesn’t scale; not a real config model |
 
 ---
 
-## 11. Open questions (resolve during F-071 if needed)
+## 11. Relationship to forma-core
 
-1. **Duplicate apply** with Mode 2: warn vs silent — default silent (Gradle-safe).
-2. **String vs PluginDependency** from version catalog (`libs.plugins.*`):
-   nice follow-up to accept `Provider<PluginDependency>` in `plugin(…)`; not
-   required for first slice if ids remain strings (classpath already resolved).
-3. **Owner/visibility params** unused on some targets today — out of scope;
-   don’t block plugins work on cleanup.
+| Concept | Layer |
+|---------|--------|
+| `TargetType`, `TargetRegistration`, allow-lists, content rules | `tools.forma:core` |
+| `PluginBinding`, `registerTargetPlugin`, `TargetPluginConfig`, apply | Gradle / `:deps` + platform plugins |
+| Custom type = `TargetRegistration` + type-owned plugin list | Registration in platform; pure graph fields stay core |
+
+Core must not hard-code Google/AndroidX plugin ids.
 
 ---
 
-## 12. Summary
+## 12. Open questions (resolve in F-071)
 
-**Deprecate** chain-based `TargetBuilder` plugin support.  
-**Standardize** on `plugins: TargetPlugins` as a **single argument of every
-target definition**.  
-**Simple** = list of plugin ids/specs in that arg.  
-**Complex** = same arg with typed `plugin(id) { extension… }` + optional deps.  
-**Separate target types** only when the plugin creates a new *role*, not for
-wiring convenience.
+1. **Multiple bindings in one `pluginConfig`** on Path A — allow ordered list of
+   registered bindings (still one arg) vs force Path B whenever N>1.  
+   **Lean allow list of registered bindings** for binary (GMS+Crashlytics).
+2. **Path B instance config** — configure-only vs allow additive bindings.  
+   **Lean configure-only** for v1.
+3. **Suffix sharing** — custom `navigation-res` vs shared `res` suffix with
+   distinct type id. Prefer distinct type id; suffix policy follows existing
+   matrix / naming rules.
+4. **Catalog `libs.plugins.*` handles** as `PluginBinding` source — nice
+   follow-up; not required if registration takes plugin id string after
+   classpath is already set up.
+
+---
+
+## 13. Summary
+
+| | |
+|--|--|
+| **Deprecate** | Chain `withPlugin` / `PluginWrapper` UX |
+| **Pre-defined types** | **Static** `registerTargetPlugin` → target takes optional **`pluginConfig`** |
+| **Custom types** | **Plugin identity on the type** → instance optional **`pluginConfig`** |
+| **Uniform config** | Single `pluginConfig: TargetPluginConfig` arg everywhere |
+| **Never** | Free-form plugin id lists on every target definition |

--- a/docs/TARGET-PLUGINS.md
+++ b/docs/TARGET-PLUGINS.md
@@ -2,9 +2,12 @@
 
 Design contract for **external Gradle plugin support on Forma targets**.
 
-**Status:** accepted design (revised). Prior free-form `plugins = plugins(…)`
-list-on-every-target sketch is **rejected** (see §10).
+**North star:** call sites should feel like **Bazel `BUILD` rules** — declare the
+target kind + attributes. Plugin identity is part of the **rule / target type**,
+not restated on every module. Extending a type with a plugin **auto-applies** that
+plugin on every call site of that type.
 
+**Status:** accepted design (3rd revision).  
 **Implementation:** F-071…F-073.
 
 **Related:** [`DEPS-CATALOG.md`](DEPS-CATALOG.md), [`ARCHITECTURE.md`](ARCHITECTURE.md),
@@ -14,357 +17,263 @@ list-on-every-target sketch is **rejected** (see §10).
 
 ## 1. Problem
 
-Today external plugins are bolted on via **chain API**:
+Today external plugins are bolted on via a **chain API** at each module:
 
 ```kotlin
 androidRes(…).withPlugin(Plugins.navigationSafeArgs)
 // androidBinary(…).withPlugins(Plugins.googleServices, Plugins.crashlytics())
 ```
 
-Issues:
+That is the opposite of Bazel:
 
-1. **Plugin identity is chosen ad hoc at each module** (`PluginWrapper` + raw
-   plugin ids) — not tied to target *types* or a registration surface.
-2. **Not uniform** — only some DSLs return `TargetBuilder`.
-3. **Split definition** — target call vs `.withPlugin` chain.
-4. **No custom-target story** — can’t say “this target *kind* always carries
-   plugin X; instances only pass config.”
-5. GH **#36** (docs) never closed because the product API was wrong.
+| Bazel | Forma today (broken) |
+|-------|----------------------|
+| Rule definition owns toolchains / aspects / implicit deps | Each `build.gradle.kts` re-selects plugins |
+| `BUILD` file only sets **attributes** | `.withPlugin` after the target call |
+| Using `my_rule(...)` always gets the rule’s behavior | Easy to forget safe-args on one res module |
+
+Also: only some DSLs return `TargetBuilder`; docs (GH #36) never shipped.
 
 Catalog dependency-driven apply (KSP) and internal `FeatureDefinition` (AGP /
-Kotlin / Compose) stay separate — they are not this design.
+Kotlin / Compose) stay separate.
 
 ---
 
-## 2. Design principle (product intent)
+## 2. Design principle
 
-> **Plugin identity is not a free-form list on every target call.**
+> **The target type (rule) owns the plugin. Call sites never pass plugin ids.**
+>
+> Extending a type with a plugin **automatically applies** it on **every** call
+> site of that type — Bazel semantics in Gradle files.
 
-Two supported ways to attach an external Gradle plugin:
+| Layer | Owns | Analogy |
+|-------|------|---------|
+| **Type / rule registration** | Plugin identity (+ optional default config schema) | `rule()` / macro definition in `.bzl` |
+| **Target definition** (`build.gradle.kts`) | Attributes only: package, deps, flags, optional **plugin config attrs** | `BUILD` target |
 
-| Path | When | Where plugin id lives | What the target definition takes |
-|------|------|------------------------|-----------------------------------|
-| **A. Static registration** | Using **pre-defined** target types (`impl`, `api`, `androidRes`, `androidBinary`, …) | **Static registration API** (settings / platform bootstrap) | Optional **plugin config** only (uniform shape) |
-| **B. Custom target type** | Plugin defines a reusable *kind* of module | **On the target type** registration | Same optional **plugin config** arg |
-
-**Not supported as the product API:**
+### Rejected shapes
 
 ```kotlin
-// REJECTED — free-form plugin shopping list on every module
-androidRes(..., plugins = plugins(plugin("some.id"), plugin("other.id")))
-```
+// REJECTED — free-form plugin list on every module
+androidRes(..., plugins = plugins(plugin("some.id")))
 
-That reintroduces unstructured Gradle habits Forma exists to remove.
+// REJECTED — re-state binding at every call site (still not Bazel)
+androidRes(..., pluginConfig = pluginConfig(navigationSafeArgs))
+
+// REJECTED — chain API
+androidRes(...).withPlugin(Plugins.navigationSafeArgs)
+```
 
 ---
 
-## 3. Goals and non-goals
+## 3. Bazel → Forma mapping
 
-### Goals
+```text
+Bazel                              Forma (Gradle KTS)
+─────────────────────────────      ──────────────────────────────────────────
+load(":defs.bzl", "nav_res")       // type registered once (settings / buildSrc / included build)
+nav_res(                           navigationRes(          // or generated DSL name
+    name = "navigation",               // project name = directory (includer)
+    package_name = "...",              packageName = "...",
+    deps = ["//lib:nav"],              dependencies = deps(...),
+)                                  )
+```
 
-1. **Deprecate** `TargetBuilder.withPlugin` / `withPlugins` and public
-   `PluginWrapper` as the consumer UX.
-2. **Static API** to register external plugins for use with **pre-defined**
-   target types (handles / bindings — not raw id soup at each callsite).
-3. **Custom target types** declare **plugin (identity) on the type**; instances
-   pass optional **config**.
-4. **Uniform plugin config** model for the per-target-definition argument
-   (simple: omit or empty; complex: single config arg — not a second chain API).
-5. Keep Mode “catalog / KSP” and Mode “platform features” unchanged and documented
-   as different concerns.
+Plugin `androidx.navigation.safeargs.kotlin` is attached when **`navigationRes`**
+(the rule/type) is defined — not when each target is written.
 
-### Non-goals
+```text
+Bazel                              Forma
+─────────────────────────────      ──────────────────────────────────────────
+firebase_android_binary(           firebaseBinary(
+    name = "app",                      packageName = "...",
+    mapping_file_upload = False,       versionCode = 1,
+    ...                                versionName = "0.0.1",
+)                                      mappingFileUploadEnabled = false, // attr
+                                       dependencies = deps(...),
+                                   )
+```
 
-| Concern | Decision |
-|---------|----------|
-| Arbitrary multi-plugin lists on every built-in DSL | **Rejected** |
-| Replacing `FeatureDefinition` for AGP/Kotlin/Compose | Out of scope |
-| Replacing catalog `plugin()` + companion-lib apply | Out of scope |
-| Plugin classpath / Portal resolution redesign | Out of scope |
-| One new built-in DSL per popular plugin (`safeArgsRes` as forever core) | Prefer **custom type** in the consumer graph, or static binding + config |
+Config looks like **rule attributes**, not a separate plugin DSL bolted on the side.
 
 ---
 
-## 4. Conceptual model
+## 4. Two registration paths
 
-```
-┌──────────────────────────────────────────────────────────────────────┐
-│ Platform features (internal)                                         │
-│   FeatureDefinition — AGP, kotlin-android, compose compiler, …       │
-└──────────────────────────────────────────────────────────────────────┘
-┌──────────────────────────────────────────────────────────────────────┐
-│ Dependency-driven (catalog)                                          │
-│   settings plugin(id, CustomConfiguration, companion libs)           │
-│   → apply when target depends on companion artifact (KSP, …)         │
-└──────────────────────────────────────────────────────────────────────┘
-┌──────────────────────────────────────────────────────────────────────┐
-│ External plugins (THIS DESIGN)                                       │
-│                                                                      │
-│  Path A — pre-defined types                                          │
-│    static register(PluginBinding) → optional pluginConfig on target  │
-│                                                                      │
-│  Path B — custom target type                                         │
-│    register type + plugin identity → optional pluginConfig on target │
-└──────────────────────────────────────────────────────────────────────┘
-```
+Both paths put plugin identity on the **type**. Neither puts plugin ids on call sites.
 
-**Invariant:** at a target *call site*, consumers configure plugins only through
-a **uniform optional config argument** (and/or a registered binding reference).
-They do not pass open-ended lists of plugin ids.
+### Path A — Extend a **pre-defined** target type (static API)
 
----
-
-## 5. Path A — Static registration (pre-defined target types)
-
-### 5.1 Registration API (settings / root / platform config time)
-
-Register plugin bindings once. Registration creates a **typed handle** the rest
-of the build refers to — plugin id, optional default companion deps, optional
-allowed pre-defined target types, optional extension type.
+Use when many/all modules of an existing kind should carry a plugin, or when you
+want a thin alias over a built-in kind without a new suffix.
 
 ```kotlin
-// Conceptual public API (names flexible in F-071)
+// Registered once (settings / androidProjectConfiguration / platform bootstrap)
+// Conceptual API — names finalized in F-071
 
-interface PluginBinding<E : Any = Any> {
-    val id: String
-    // implementation details: extension KClass, default deps, allowed types
-}
-
-// Static registration — e.g. next to androidProjectConfiguration / settings
-fun <E : Any> registerTargetPlugin(
-    id: String,
-    extensionClass: KClass<E>? = null,
-    allowedTypes: Set<TargetType> = emptySet(), // empty = any pre-defined type that accepts config
-    dependencies: FormaDependency = emptyDependency(),
-): PluginBinding<E>
-```
-
-**Sample registration (app or `build-dependencies`):**
-
-```kotlin
-val navigationSafeArgs = registerTargetPlugin(
-    id = "androidx.navigation.safeargs.kotlin",
-    allowedTypes = setOf(AndroidTargetTypes.res),
+registerTargetPlugin(
+    // which pre-defined type is being extended
+    targetType = AndroidTargetTypes.res,
+    pluginId = "androidx.navigation.safeargs.kotlin",
 )
 
-val googleServices = registerTargetPlugin(
-    id = "com.google.gms.google-services",
-    allowedTypes = setOf(AndroidTargetTypes.binary, AndroidTargetTypes.app),
-)
-
-val crashlytics = registerTargetPlugin(
-    id = "com.google.firebase.crashlytics",
-    extensionClass = CrashlyticsExtension::class,
-    allowedTypes = setOf(AndroidTargetTypes.binary),
-    dependencies = google.firebase,
-)
-```
-
-Classpath / version resolution stays with existing `pluginManagement` /
-`buildscript` / catalog markers — registration does not replace that.
-
-### 5.2 Pre-defined target definition — optional config only
-
-Built-in DSLs gain a **uniform optional** argument for plugin configuration —
-not a vararg plugin id list.
-
-```kotlin
-/**
- * Uniform per-target plugin configuration.
- *
- * - [binding] — handle from [registerTargetPlugin] (required if any plugin apply is requested)
- * - [configure] — optional extension configuration when the binding has an extension type
- *
- * Multiple plugins on one pre-defined module: prefer Path B (custom type that
- * owns the plugin set), or a single composite binding if F-071 finds a clean shape.
- * v1 may allow a small ordered list of [PluginUse] inside one config arg — still
- * one parameter, still only registered bindings (no raw ids).
- */
-class TargetPluginConfig private constructor(
-    val uses: List<PluginUse>,
-) {
-    companion object {
-        val None: TargetPluginConfig = TargetPluginConfig(emptyList())
-    }
-}
-
-class PluginUse internal constructor(
-    val binding: PluginBinding<*>,
-    val configure: (Any.() -> Unit)? = null,
-)
-
-fun pluginConfig(binding: PluginBinding<*>): TargetPluginConfig =
-    TargetPluginConfig(/* single use, no configure */)
-
-fun <E : Any> pluginConfig(
-    binding: PluginBinding<E>,
-    configure: E.() -> Unit,
-): TargetPluginConfig = …
-
-fun pluginConfig(vararg uses: PluginUse): TargetPluginConfig = …
-fun <E : Any> PluginBinding<E>.withConfig(configure: E.() -> Unit): PluginUse = …
-```
-
-**Call sites (pre-defined types):**
-
-```kotlin
-// Simple — registered binding, no extension config
+// From this point, EVERY androidRes(...) call site auto-applies safe-args.
 androidRes(
     packageName = "tools.forma.sample.core.navigation.library",
     dependencies = deps(androidx.navigation),
-    pluginConfig = pluginConfig(navigationSafeArgs),
-)
-
-// Complex — still one arg; registered bindings only (no raw ids)
-androidBinary(
-    packageName = "tools.forma.sample.app",
-    versionCode = 1,
-    versionName = "0.0.1",
-    dependencies = deps(/* … */),
-    pluginConfig = pluginConfig(
-        googleServices,
-        crashlytics.withConfig {
-            mappingFileUploadEnabled = false
-        },
-    ),
-)
-**Rules**
-
-1. Only **registered** bindings — raw plugin id strings are not accepted on
-   target DSLs.
-2. If `allowedTypes` is non-empty, binding must be allowed for that target’s
-   `TargetType` or configuration fails fast.
-3. Apply order: platform features → target plugins from config → dependencies
-   (same as today’s need for AGP-before-safe-args).
-4. Default: `pluginConfig = TargetPluginConfig.None` (no external plugins).
-
-This is “static API for plugin registration” + “plugin config as part of target
-definition” for pre-defined types.
-
----
-
-## 6. Path B — Custom target type + plugin on the type
-
-When a plugin (or fixed plugin set) **defines a reusable module kind**, put
-plugin identity on the **type**, not on every instance.
-
-### 6.1 Type registration
-
-Extend registration beyond pure `TargetRegistration` (restriction/content) with
-optional Gradle plugin identity owned by the type:
-
-```kotlin
-// Conceptual — platform Gradle layer (not pure forma-core)
-
-data class CustomTargetType(
-    val registration: TargetRegistration, // type id, suffix, allow-list, content rules
-    /**
-     * Plugin(s) always applied for this kind.
-     * Identity lives here — instances do not re-state plugin ids.
-     */
-    val plugins: List<PluginBinding<*>> = emptyList(),
-    // optional: factory for default pluginConfig
-)
-
-// Consumer / platform helper
-fun registerCustomAndroidTarget(
-    id: String,
-    nameSuffix: String,
-    allowedDependencies: Set<TargetType>,
-    contentRules: List<ContentRule> = emptyList(),
-    plugins: List<PluginBinding<*>> = emptyList(),
-    // or single plugin: plugin: PluginBinding<*>? = null
-): CustomTargetType
+) // ← no plugin mention; type already carries it
 ```
 
-**Example — navigation graphs kind:**
+**Caution:** Path A is global for that pre-defined type in the registry scope.
+If only *some* res modules need safe-args, use **Path B** (derived type) so
+plain `androidRes` stays clean.
+
+Static API responsibilities:
+
+- Associate `pluginId` (+ optional companion deps, extension class) with a
+  `TargetType` already in `TargetRegistry`
+- Optional: default attribute values / schema for plugin config
+- Idempotent apply at configuration time for every project that uses that type’s DSL
+
+### Path B — **Custom / derived target type** (preferred for selective use)
+
+Use when the plugin defines a **reusable kind** of module (Bazel: new rule or
+macro wrapping a base rule).
 
 ```kotlin
-val navigationSafeArgs = registerTargetPlugin(
+// defs — once
+val navigationSafeArgs = targetPlugin(
     id = "androidx.navigation.safeargs.kotlin",
 )
 
-val navigationRes = registerCustomAndroidTarget(
+val navigationRes = deriveTargetType(
     id = "sample.navigation-res",
-    nameSuffix = "res", // or "navigation-res" if suffix isolation desired
-    allowedDependencies = setOf(
-        AndroidTargetTypes.res,
-        AndroidTargetTypes.widget,
-        AndroidTargetTypes.composeWidget,
-    ),
-    contentRules = listOf(OnlyResourcesUnderMain),
+    base = AndroidTargetTypes.res,       // matrix, content rules, AGP library features
+    nameSuffix = "res",                  // or "navigation-res" if isolation desired
     plugins = listOf(navigationSafeArgs),
+)
+
+// Optional: expose a DSL entrypoint bound to that type
+fun Project.navigationRes(
+    packageName: String,
+    dependencies: FormaDependency = emptyDependency(),
+    // plugin-specific attrs only if needed — see §5
+) = androidTarget(
+    type = navigationRes,
+    packageName = packageName,
+    dependencies = dependencies,
 )
 ```
 
-### 6.2 Instance definition — optional config only
+**Every** `navigationRes { … }` call site auto-applies safe-args. Call sites stay
+Bazel-flat:
 
 ```kotlin
-// Generated or generic DSL — shape is what matters
+// application/core/navigation/res/build.gradle.kts
 navigationRes(
     packageName = "tools.forma.sample.core.navigation.library",
     dependencies = deps(androidx.navigation),
-    // plugin id already on the type — only optional config:
-    pluginConfig = TargetPluginConfig.None,
+)
+```
+
+No `.withPlugin`, no `pluginConfig = pluginConfig(binding)`.
+
+---
+
+## 5. Plugin config = rule attributes (uniform, optional)
+
+When a plugin needs per-target settings (Crashlytics mapping upload, etc.):
+
+1. **Simple / no knobs** — type has the plugin; call site has **zero** plugin surface.
+2. **Complex** — either:
+   - **Derived type** with extra attributes on that type’s DSL (Bazel rule attrs), or
+   - **Single optional config arg** on that type’s DSL whose shape is defined with
+     the type (not a free-form plugin id list)
+
+```kotlin
+// Type definition owns plugin + config schema
+val crashlytics = targetPlugin(
+    id = "com.google.firebase.crashlytics",
+    extensionClass = CrashlyticsExtension::class,
+    dependencies = google.firebase,
+)
+val googleServices = targetPlugin(id = "com.google.gms.google-services")
+
+val firebaseBinary = deriveTargetType(
+    id = "sample.firebase-binary",
+    base = AndroidTargetTypes.binary,
+    plugins = listOf(googleServices, crashlytics),
+    // schema: which attrs map into plugin extensions
 )
 
-// With extension config (single uniform arg)
+// Call site — Bazel-like attributes only
+firebaseBinary(
+    packageName = "tools.forma.sample.app",
+    versionCode = 1,
+    versionName = "0.0.1",
+    mappingFileUploadEnabled = false, // rule attr → CrashlyticsExtension
+    dependencies = deps(/* … */),
+)
+```
+
+**Uniform config model (implementation detail):** types may accept one optional
+`pluginConfig: T? = null` where `T` is a **type-associated** config data class —
+not `List<PluginId>`. Prefer first-class named attrs on the DSL when there are
+few knobs (more Bazel-like).
+
+```kotlin
+// Acceptable single-arg form when attrs would explode the signature
 firebaseBinary(
     packageName = "…",
     versionCode = 1,
     versionName = "0.0.1",
     dependencies = deps(/* … */),
-    pluginConfig = pluginConfig(
-        crashlytics.withConfig { mappingFileUploadEnabled = false },
-    ),
+    pluginConfig = CrashlyticsConfig(mappingFileUploadEnabled = false),
 )
 ```
 
-**Apply semantics for Path B**
-
-1. Validate self-type / content from `TargetRegistration`.
-2. Apply platform features for the base kind (library vs binary vs …).
-3. Apply **type-owned** plugins (always).
-4. Apply **instance** `pluginConfig` (extra bindings only if the type allows
-   overrides; v1 can restrict instance config to configuring type-owned
-   plugins’ extensions — simplest and clearest).
-5. `applyDependencies`.
-
-**Recommendation for v1 instance config on Path B:** `pluginConfig` only
-**configures** plugins already declared on the type (extension lambdas keyed by
-binding). It does **not** add new plugin ids. That keeps type = identity,
-instance = config.
+Still: **no plugin ids at the call site.** Config type is fixed by the rule.
 
 ---
 
-## 7. Uniform `pluginConfig` argument
+## 6. Runtime sequence (Bazel “rule implementation”)
 
-Across **all** pre-defined DSLs and custom-target entrypoints:
+For a project using type `T`:
 
-```kotlin
-pluginConfig: TargetPluginConfig = TargetPluginConfig.None
+```
+1. Resolve TargetRegistration for T (suffix, allow-list, content rules)
+2. Self-validate project name; run content rules
+3. applyFeatures — platform FeatureDefinitions for base kind (AGP, Kotlin, …)
+4. apply type-owned external plugins   ← automatic from type; never from call-site ids
+5. apply plugin config attributes (if any) onto plugin extensions
+6. applyDependencies (catalog Mode-2 side effects may still apply KSP, etc.)
 ```
 
-| Case | Shape |
-|------|--------|
-| No external plugin | omit / `None` |
-| Simple (apply registered / type-owned plugin, no extension knobs) | `pluginConfig = pluginConfig(binding)` or type-owned with `None` |
-| Complex extension settings | **single** `pluginConfig = pluginConfig(binding.withConfig { … })` |
-| Complex *kind* (different role or permanent plugin set) | **Path B** custom target type |
-
-No `.withPlugin` chain. No second structural style.
+Extending the type updates step 4 for **all** existing and future call sites.
 
 ---
 
-## 8. Deprecation plan
+## 7. Pre-defined DSLs after this work
+
+Built-in entrypoints (`impl`, `api`, `androidRes`, `androidBinary`, …):
+
+- Return **`Unit`** (no `TargetBuilder` chain).
+- Do **not** grow a `plugins = …` parameter.
+- If Path A registered plugins on their `TargetType`, those apply automatically
+  inside the DSL implementation via registry lookup.
+- Optional plugin-related **attributes** only appear on **derived** DSLs (Path B)
+  or on a pre-defined DSL if Path A attached a config schema (rare).
+
+---
+
+## 8. Deprecation
 
 | Remove / deprecate | Replacement |
 |--------------------|-------------|
-| `TargetBuilder.withPlugin` | Path A `pluginConfig` or Path B custom type |
-| `TargetBuilder.withPlugins` | same |
-| Public `PluginWrapper` / sample `Plugins.kt` wrappers as apply API | `registerTargetPlugin` + bindings |
-| `pluginConfiguration { }` user construction | `binding.withConfig { }` inside `pluginConfig` |
-| Returning `TargetBuilder` solely for chaining | Return `Unit`; temporary deprecated shim OK for one minor |
+| `TargetBuilder.withPlugin` / `withPlugins` | Type-owned plugins (Path A or B) |
+| Public `PluginWrapper` + sample `Plugins.kt` apply API | `targetPlugin` + `deriveTargetType` / `registerTargetPlugin` |
+| Call-site plugin id lists / binding re-selection | Impossible in the new API |
+| `TargetBuilder` return values for chaining | `Unit` + temporary deprecated shim |
 
 **Sample migration**
 
@@ -375,15 +284,15 @@ androidRes(
     dependencies = deps(androidx.navigation),
 ).withPlugin(Plugins.navigationSafeArgs)
 
-// AFTER — Path A
-androidRes(
+// AFTER — Path B (typical)
+navigationRes(
     packageName = "…",
     dependencies = deps(androidx.navigation),
-    pluginConfig = pluginConfig(navigationSafeArgs), // registered handle
 )
 
-// AFTER — Path B (preferred if every navigation res always needs safe-args)
-navigationRes(
+// AFTER — Path A only if ALL androidRes modules should get safe-args
+// registerTargetPlugin(AndroidTargetTypes.res, safeArgs) once, then:
+androidRes(
     packageName = "…",
     dependencies = deps(androidx.navigation),
 )
@@ -391,24 +300,15 @@ navigationRes(
 
 ```kotlin
 // BEFORE
-androidBinary(… )
-    .withPlugins(Plugins.googleServices, Plugins.crashlytics())
+androidBinary(…).withPlugins(Plugins.googleServices, Plugins.crashlytics())
 
-// AFTER — Path A with single config arg
-androidBinary(
-    …,
-    pluginConfig = pluginConfig(
-        googleServices,
-        crashlytics.withConfig { mappingFileUploadEnabled = false },
-    ),
-)
-
-// AFTER — Path B if this binary kind is always “firebase app binary”
+// AFTER
 firebaseBinary(
-    …,
-    pluginConfig = pluginConfig(
-        crashlytics.withConfig { mappingFileUploadEnabled = false },
-    ),
+    packageName = "…",
+    versionCode = 1,
+    versionName = "0.0.1",
+    mappingFileUploadEnabled = false,
+    dependencies = deps(/* … */),
 )
 ```
 
@@ -418,50 +318,47 @@ firebaseBinary(
 
 | ID | Scope | Acceptance |
 |----|--------|------------|
-| **F-070** | This design (revised) | Merged on `v2` |
-| **F-071** | `PluginBinding`, `registerTargetPlugin`, `TargetPluginConfig`, `applyTargetPluginConfig`; wire **optional `pluginConfig`** on all Android/JVM pre-defined DSLs; reject raw plugin ids | unit tests; plugins build green |
-| **F-072** | Custom target type registration with type-owned plugins + instance config; migrate sample (safe-args ± binary); deprecate `TargetBuilder` / `PluginWrapper` | application green; no `.withPlugin` call sites |
-| **F-073** | User docs + progressive example + agent skill; close GH #36 | docs match Paths A/B only |
+| **F-070** | This design | Merged on `v2` |
+| **F-071** | `targetPlugin`, type→plugin registry, auto-apply in pre-defined DSLs (Path A lookup), `deriveTargetType` core hooks | unit tests: type with plugin applies without call-site API; plugins build green |
+| **F-072** | Path B DSL helpers; migrate sample navigation (+ optional firebase binary type); deprecate `TargetBuilder` / `PluginWrapper` | application green; **zero** `.withPlugin` call sites; call sites Bazel-flat |
+| **F-073** | Docs + progressive example + agent skill; close GH #36 | examples match §3 mapping |
 
 ---
 
-## 10. Rejected alternatives
+## 10. Rejected alternatives (history)
 
 | Alternative | Why rejected |
 |-------------|--------------|
-| **Free-form `plugins = plugins(plugin("id"), …)` on every target** | Exactly the unstructured surface this work should avoid; plugin identity belongs on **registration** or **custom type** |
-| Keep chain-only `TargetBuilder` | Split definition; inconsistent return types |
-| Plugins only via catalog companion libs | Safe-args / GMS are not “consume this one library” |
-| New core built-in DSL per plugin (`safeArgsAndroidRes`) | Explodes platform surface; Path B custom types cover consumer graphs |
-| Multi-arg `safeArgs=`, `crashlytics=` booleans on every DSL | Not uniform; doesn’t scale; not a real config model |
+| Free-form `plugins = plugins(plugin("id")…)` on every target | Unstructured; anti-Bazel |
+| Call-site `pluginConfig = pluginConfig(registeredBinding)` | Still re-selects plugins per module; first “Path A” example was **wrong** |
+| Chain `TargetBuilder.withPlugin` | Split definition; inconsistent returns |
+| New forever built-in core DSL per vendor plugin | Prefer consumer Path B derived types |
+| Catalog-only | Safe-args / GMS are not companion-lib driven |
 
 ---
 
-## 11. Relationship to forma-core
+## 11. forma-core vs Gradle layer
 
 | Concept | Layer |
 |---------|--------|
-| `TargetType`, `TargetRegistration`, allow-lists, content rules | `tools.forma:core` |
-| `PluginBinding`, `registerTargetPlugin`, `TargetPluginConfig`, apply | Gradle / `:deps` + platform plugins |
-| Custom type = `TargetRegistration` + type-owned plugin list | Registration in platform; pure graph fields stay core |
+| `TargetType`, allow-lists, content rules, registry | `tools.forma:core` |
+| Type → external plugin bindings, auto-apply, config→extension | Gradle `:deps` / platform plugins |
+| Derived type = core registration + plugin list | Platform registration API |
 
-Core must not hard-code Google/AndroidX plugin ids.
+Core does not hard-code AndroidX/Google plugin ids.
 
 ---
 
-## 12. Open questions (resolve in F-071)
+## 12. Open questions (F-071)
 
-1. **Multiple bindings in one `pluginConfig`** on Path A — allow ordered list of
-   registered bindings (still one arg) vs force Path B whenever N>1.  
-   **Lean allow list of registered bindings** for binary (GMS+Crashlytics).
-2. **Path B instance config** — configure-only vs allow additive bindings.  
-   **Lean configure-only** for v1.
-3. **Suffix sharing** — custom `navigation-res` vs shared `res` suffix with
-   distinct type id. Prefer distinct type id; suffix policy follows existing
-   matrix / naming rules.
-4. **Catalog `libs.plugins.*` handles** as `PluginBinding` source — nice
-   follow-up; not required if registration takes plugin id string after
-   classpath is already set up.
+1. **Path A scope** — settings-wide vs project hierarchy. Lean: same scope as
+   `TargetRegistry` / `androidProjectConfiguration`.
+2. **Suffix** for derived types — share `res` vs `navigation-res`. Document
+   tradeoff; sample may keep `res` suffix with distinct type id.
+3. **Config wiring** — named DSL attrs vs single `pluginConfig: T`. Prefer named
+   attrs when ≤3 knobs; single typed config arg otherwise.
+4. **Multiple plugins on one type** — ordered list on the type (GMS then
+   Crashlytics); call site still silent.
 
 ---
 
@@ -469,8 +366,9 @@ Core must not hard-code Google/AndroidX plugin ids.
 
 | | |
 |--|--|
-| **Deprecate** | Chain `withPlugin` / `PluginWrapper` UX |
-| **Pre-defined types** | **Static** `registerTargetPlugin` → target takes optional **`pluginConfig`** |
-| **Custom types** | **Plugin identity on the type** → instance optional **`pluginConfig`** |
-| **Uniform config** | Single `pluginConfig: TargetPluginConfig` arg everywhere |
-| **Never** | Free-form plugin id lists on every target definition |
+| **Model** | Bazel rules in Gradle files |
+| **Plugin identity** | On the **target type** (static extend pre-defined **or** derived type) |
+| **Call site** | Attributes only — **auto-apply** type plugins every time |
+| **Config** | Rule attributes or one type-associated config arg — **never** plugin ids |
+| **Deprecate** | `.withPlugin` / `PluginWrapper` chain |
+| **Never** | Per-module plugin shopping lists or re-binding at each target |

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -50,7 +50,7 @@ Concrete stacks built **on** forma-core:
 3. **JVM implementation** — prove core is portable.
 4. **Bazel** — design + implement adapter once core is stable (see [`docs/BAZEL-ADAPTER.md`](BAZEL-ADAPTER.md) for the F-040 mapping design).
 5. **Flat-structure hardening** — deprecate/remove generic targets that undermine role typing (P6 / F-060+).
-6. **Uniform target plugins** — external Gradle plugins via **static registration** (pre-defined types) or **plugin on custom target type**, plus optional uniform `pluginConfig` on target definitions; deprecate chain `withPlugin`; **no** free-form plugin id lists (P7 / F-070+; [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md)).
+6. **Uniform target plugins** — Bazel-like: plugin on the **target type**, auto-apply on every call site; call sites are attributes-only; deprecate chain `withPlugin` (P7 / F-070+; [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md)).
 
 ## Working principles
 

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -50,7 +50,7 @@ Concrete stacks built **on** forma-core:
 3. **JVM implementation** — prove core is portable.
 4. **Bazel** — design + implement adapter once core is stable (see [`docs/BAZEL-ADAPTER.md`](BAZEL-ADAPTER.md) for the F-040 mapping design).
 5. **Flat-structure hardening** — deprecate/remove generic targets that undermine role typing (P6 / F-060+).
-6. **Uniform target plugins** — external Gradle plugins as a single `plugins` arg on every target definition; deprecate chain `withPlugin` (P7 / F-070+; [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md)).
+6. **Uniform target plugins** — external Gradle plugins via **static registration** (pre-defined types) or **plugin on custom target type**, plus optional uniform `pluginConfig` on target definitions; deprecate chain `withPlugin`; **no** free-form plugin id lists (P7 / F-070+; [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md)).
 
 ## Working principles
 


### PR DESCRIPTION
## Summary
Corrects F-070 after product feedback: **do not** put free-form `plugins = plugins(plugin(\"id\")…)` on every target.

### Correct model
| Path | Plugin identity | Target definition |
|------|-----------------|-------------------|
| **A** pre-defined types | **Static** `registerTargetPlugin` | optional uniform `pluginConfig` |
| **B** custom target type | **On the type** | same optional `pluginConfig` |

Deprecate chain `withPlugin` / `PluginWrapper`. Catalog KSP + FeatureDefinition unchanged.

Full rewrite: `docs/TARGET-PLUGINS.md`. TICKETS F-071–F-073 notes aligned.

## Test plan
- [x] Docs-only