### PR TITLE
F-071: type-owned target plugins registry + auto-apply

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -91,7 +91,7 @@ Close the biggest call-site / multi-way gap: chain `withPlugin`. Design:
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
 | F-070 | done | Design type-owned plugins API | Bazel north star; type owns plugin; auto-apply; reject free-form lists + call-site binding re-selection |
-| F-071 | todo | **Implement** type→plugin registry + auto-apply; `targetPlugin` / `deriveTargetType` | Unit tests: type with plugin applies with **zero** call-site plugin API; plugins build green; shims OK |
+| F-071 | done | **Implement** type→plugin registry + auto-apply; `targetPlugin` / `deriveTargetType` | `TargetPluginSpec` + registry + Path A/B; `applyTargetPlugins` on all Android DSLs; unit tests; plugins build green; legacy shims kept for F-072 |
 | F-072 | todo | Migrate sample to derived types (e.g. `navigationRes`); hard-deprecate chain | Zero `.withPlugin` in tree; `TargetBuilder`/`PluginWrapper` `@Deprecated` or removed; application green |
 | F-073 | todo | User docs + progressive example + agent skill; close GH #36 | Call sites attributes-only; registration/type layer documented |
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,23 @@
 
 Newest entries first.
 
+## 2026-07-19 — F-071: type-owned target plugins registry + auto-apply
+
+- **Ticket:** F-071 → `done`
+- **Branch / PR:** `forma/F-071-target-plugins` → base `v2`
+- **Skills/modes:** Grok Build `--mode full` (design + partial implement, max-turns); Hermes finish path: compile fixes, unit tests, remaining DSL verify, bookkeeping
+- **Code:**
+  - `plugins/deps`: `TargetPluginSpec` / `targetPlugin`, `TargetPluginRegistryApi` + `DefaultTargetPluginRegistry` + global `TargetPluginRegistry`, `registerTargetPlugin` (Path A), `deriveTargetType` (Path B, optional core registry clone), `Project.applyTargetPlugins`
+  - `plugins/android`: re-exports on `AndroidTargetRegistry`; **all** Android target DSLs call `applyTargetPlugins(type)` after `applyFeatures`, before `applyDependencies`
+  - Unit tests: `TargetPluginRegistryTest` (ordered register/dedupe, Path A global bind, Path B clone + plugins, empty unbound)
+  - Legacy `TargetBuilder` / `PluginWrapper` / sample `.withPlugin` **untouched** (F-072)
+- **Verify (real host, `source scripts/env-mac.sh`):**
+  - `plugins/ ./gradlew :deps:test :android:compileKotlin` → SUCCESS
+  - `plugins/ ./gradlew build` → **BUILD SUCCESSFUL** (78 tasks)
+  - `application/ ./gradlew help` → **BUILD SUCCESSFUL** (legacy path still configures)
+- **Blockers:** none
+- **Next:** F-072 migrate sample to derived types (e.g. `navigationRes`); hard-deprecate `TargetBuilder` / `.withPlugin`
+
 ## 2026-07-19 — P8 board: principle-alignment tickets + F-080 docs
 
 - **User ask:** create tickets to update implementation to match Forma goals (3 root principles)

--- a/docs/TARGET-PLUGINS.md
+++ b/docs/TARGET-PLUGINS.md
@@ -7,8 +7,8 @@ target kind + attributes. Plugin identity is part of the **rule / target type**,
 not restated on every module. Extending a type with a plugin **auto-applies** that
 plugin on every call site of that type.
 
-**Status:** accepted design (3rd revision).  
-**Implementation:** F-071…F-073.
+**Status:** F-070 design accepted (3rd revision). **F-071 implemented** (type→plugin registry + auto-apply).  
+**Remaining:** F-072 sample migrate / deprecate chain · F-073 docs / GH #36.
 
 **Related:** [`DEPS-CATALOG.md`](DEPS-CATALOG.md), [`ARCHITECTURE.md`](ARCHITECTURE.md),
 [`forma-core-api.md`](forma-core-api.md), `TargetRegistry` / `TargetRegistration`.

--- a/plugins/android/src/main/java/androidApp.kt
+++ b/plugins/android/src/main/java/androidApp.kt
@@ -13,6 +13,7 @@ import tools.forma.android.visibility.Visibility
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.NamedDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
 import tools.forma.validation.asValidator
@@ -57,6 +58,7 @@ fun Project.androidApp(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.app)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.app).asValidator(),

--- a/plugins/android/src/main/java/androidBinary.kt
+++ b/plugins/android/src/main/java/androidBinary.kt
@@ -8,6 +8,7 @@ import tools.forma.android.utils.BuildConfiguration
 import tools.forma.android.validation.disallowResources
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
 import tools.forma.validation.asValidator
@@ -60,6 +61,7 @@ fun Project.androidBinary(
     applyFeatures(
         androidBinaryFeatureDefinition(binaryFeatureConfiguration)
     )
+    applyTargetPlugins(AndroidTargetTypes.binary)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.binary).asValidator(),

--- a/plugins/android/src/main/java/androidNative.kt
+++ b/plugins/android/src/main/java/androidNative.kt
@@ -11,6 +11,7 @@ import tools.forma.android.visibility.Public
 import tools.forma.android.visibility.Visibility
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.validation.asValidator
 import tools.forma.validation.validate
 
@@ -33,4 +34,5 @@ fun Project.androidNative(
     applyFeatures(
         androidNativeDefinition(configuration)
     )
+    applyTargetPlugins(AndroidTargetTypes.native)
 }

--- a/plugins/android/src/main/java/androidRes.kt
+++ b/plugins/android/src/main/java/androidRes.kt
@@ -10,6 +10,7 @@ import tools.forma.android.visibility.Public
 import tools.forma.android.visibility.Visibility
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
 import tools.forma.validation.asValidator
@@ -35,6 +36,7 @@ fun Project.androidRes(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.res)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.res).asValidator(),

--- a/plugins/android/src/main/java/androidTestUtil.kt
+++ b/plugins/android/src/main/java/androidTestUtil.kt
@@ -10,6 +10,7 @@ import tools.forma.android.visibility.Public
 import tools.forma.android.visibility.Visibility
 import org.gradle.api.Project
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.deps.core.FormaDependency
 import tools.forma.validation.asValidator
 import tools.forma.validation.validate
@@ -29,6 +30,7 @@ fun Project.androidTestUtil(
         androidLibraryFeatureDefinition(androidFeatureConfig),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.androidTestUtil)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.androidTestUtil).asValidator(),

--- a/plugins/android/src/main/java/androidUtil.kt
+++ b/plugins/android/src/main/java/androidUtil.kt
@@ -12,6 +12,7 @@ import tools.forma.android.visibility.Visibility
 import org.gradle.api.Project
 import tools.forma.android.feature.kaptConfigurationFeature
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.deps.core.FormaDependency
 import tools.forma.validation.asValidator
 import tools.forma.validation.validate
@@ -56,6 +57,7 @@ fun Project.androidUtil(
         androidLibraryFeatureDefinition(androidFeatureConfig),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.androidUtil)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.androidUtil).asValidator(),

--- a/plugins/android/src/main/java/api.kt
+++ b/plugins/android/src/main/java/api.kt
@@ -7,6 +7,7 @@ import tools.forma.owners.Owner
 import tools.forma.owners.NoOwner
 import org.gradle.api.Project
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.deps.core.FormaDependency
 import tools.forma.validation.asValidator
 import tools.forma.validation.validate
@@ -30,6 +31,8 @@ fun Project.api(
     applyFeatures(
         kotlinFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.api)
+
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.api).asValidator(),
         dependencies = dependencies

--- a/plugins/android/src/main/java/composeWidget.kt
+++ b/plugins/android/src/main/java/composeWidget.kt
@@ -10,6 +10,7 @@ import tools.forma.android.visibility.Visibility
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.NamedDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
 import tools.forma.validation.asValidator
@@ -49,6 +50,7 @@ fun Project.composeWidget(
         androidLibraryFeatureDefinition(featureConfiguration),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.composeWidget)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.composeWidget).asValidator(),

--- a/plugins/android/src/main/java/impl.kt
+++ b/plugins/android/src/main/java/impl.kt
@@ -10,6 +10,7 @@ import tools.forma.android.utils.BuildConfiguration
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.NamedDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.validation.asValidator
 import tools.forma.validation.validate
 
@@ -55,6 +56,7 @@ fun Project.impl(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.impl)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.impl).asValidator(),

--- a/plugins/android/src/main/java/library.kt
+++ b/plugins/android/src/main/java/library.kt
@@ -9,6 +9,7 @@ import tools.forma.android.visibility.Visibility
 import org.gradle.api.Project
 import tools.forma.android.feature.kaptConfigurationFeature
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.NamedDependency
 import tools.forma.validation.asValidator
@@ -29,6 +30,7 @@ fun Project.library(
     applyFeatures(
         kotlinFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.jvmLibrary)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.jvmLibrary).asValidator(),

--- a/plugins/android/src/main/java/testUtil.kt
+++ b/plugins/android/src/main/java/testUtil.kt
@@ -9,6 +9,7 @@ import tools.forma.android.visibility.Public
 import tools.forma.android.visibility.Visibility
 import org.gradle.api.Project
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.deps.core.FormaDependency
 import tools.forma.validation.asValidator
 import tools.forma.validation.validate
@@ -27,6 +28,7 @@ fun Project.testUtil(
     applyFeatures(
         kotlinFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.testUtil)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.testUtil).asValidator(),

--- a/plugins/android/src/main/java/tools/forma/android/target/AndroidTargetRegistry.kt
+++ b/plugins/android/src/main/java/tools/forma/android/target/AndroidTargetRegistry.kt
@@ -3,9 +3,16 @@ package tools.forma.android.target
 import tools.forma.core.target.DefaultTargetRegistry
 import tools.forma.core.target.TargetRegistration
 import tools.forma.core.target.TargetRegistry
+import tools.forma.core.target.TargetType
 import tools.forma.core.validation.NoResourcesUnderMain
 import tools.forma.core.validation.OnlyLayoutResources
 import tools.forma.core.validation.OnlyResourcesUnderMain
+import tools.forma.deps.core.EmptyDependency
+import tools.forma.deps.core.FormaDependency
+import tools.forma.deps.core.TargetPluginSpec
+import tools.forma.deps.core.deriveTargetType as deriveTargetTypeWithCoreRegistry
+import tools.forma.deps.core.registerTargetPlugin as registerTargetPluginGlobal
+import tools.forma.deps.core.targetPlugin as targetPluginFactory
 
 /**
  * Singleton registry for Android platform target types.
@@ -171,3 +178,34 @@ fun registerAndroidDefaults(registry: TargetRegistry = AndroidTargetRegistry) {
         )
     )
 }
+
+/**
+ * Path A convenience for Android: register plugins against a pre-defined AndroidTargetType.
+ * Delegates to the shared (global) plugin registry.
+ */
+fun registerTargetPlugin(targetType: TargetType, vararg plugins: TargetPluginSpec) {
+    registerTargetPluginGlobal(targetType, *plugins)
+}
+
+/** Factory re-export for convenience in android scripts. */
+fun targetPlugin(id: String, dependencies: FormaDependency = EmptyDependency): TargetPluginSpec =
+    targetPluginFactory(id, dependencies)
+
+/**
+ * Path B for Android: derive a new TargetType from a base Android type.
+ * Clones allowedDependencies + contentRules into AndroidTargetRegistry under new id.
+ * Attaches plugins so applyTargetPlugins will pick them up for this derived kind.
+ */
+fun deriveTargetType(
+    id: String,
+    base: TargetType,
+    nameSuffix: String = base.nameSuffix,
+    plugins: List<TargetPluginSpec> = emptyList()
+): TargetType = deriveTargetTypeWithCoreRegistry(
+    id = id,
+    base = base,
+    nameSuffix = nameSuffix,
+    plugins = plugins,
+    coreRegistry = AndroidTargetRegistry
+)
+

--- a/plugins/android/src/main/java/uiLibrary.kt
+++ b/plugins/android/src/main/java/uiLibrary.kt
@@ -12,6 +12,7 @@ import tools.forma.android.visibility.Visibility
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.NamedDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
 import tools.forma.validation.asValidator
@@ -49,6 +50,7 @@ fun Project.uiLibrary(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.uiLibrary)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.uiLibrary).asValidator(),

--- a/plugins/android/src/main/java/util.kt
+++ b/plugins/android/src/main/java/util.kt
@@ -9,6 +9,7 @@ import tools.forma.android.visibility.Public
 import tools.forma.android.visibility.Visibility
 import org.gradle.api.Project
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.deps.core.FormaDependency
 import tools.forma.validation.asValidator
 import tools.forma.validation.validate
@@ -44,6 +45,7 @@ fun Project.util(
     applyFeatures(
         kotlinFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.util)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.util).asValidator(),

--- a/plugins/android/src/main/java/viewBinding.kt
+++ b/plugins/android/src/main/java/viewBinding.kt
@@ -10,6 +10,7 @@ import tools.forma.android.visibility.Public
 import tools.forma.android.visibility.Visibility
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
 import tools.forma.validation.asValidator
@@ -45,6 +46,8 @@ fun Project.viewBinding(
         androidLibraryFeatureDefinition(libraryFeatureConfiguration),
         kotlinAndroidFeatureDefinition(),
     )
+    applyTargetPlugins(AndroidTargetTypes.viewBinding)
+
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.viewBinding).asValidator(),
         dependencies = dependencies

--- a/plugins/android/src/main/java/widget.kt
+++ b/plugins/android/src/main/java/widget.kt
@@ -10,6 +10,7 @@ import tools.forma.android.visibility.Visibility
 import tools.forma.deps.core.FormaDependency
 import tools.forma.deps.core.NamedDependency
 import tools.forma.deps.core.applyDependencies
+import tools.forma.deps.core.applyTargetPlugins
 import tools.forma.owners.NoOwner
 import tools.forma.owners.Owner
 import tools.forma.validation.asValidator
@@ -46,6 +47,7 @@ fun Project.widget(
         androidLibraryFeatureDefinition(featureConfiguration),
         kotlinAndroidFeatureDefinition()
     )
+    applyTargetPlugins(AndroidTargetTypes.widget)
 
     applyDependencies(
         validator = AndroidTargetRegistry.validatorFor(AndroidTargetTypes.widget).asValidator(),

--- a/plugins/deps/src/main/java/tools.forma/deps/core/TargetPluginRegistry.kt
+++ b/plugins/deps/src/main/java/tools.forma/deps/core/TargetPluginRegistry.kt
@@ -1,0 +1,96 @@
+package tools.forma.deps.core
+
+import tools.forma.core.target.TargetRegistry
+import tools.forma.core.target.TargetRegistration
+import tools.forma.core.target.TargetType
+import tools.forma.core.target.targetType
+
+/**
+ * Associates ordered list of external [TargetPluginSpec]s with a [TargetType].
+ * Lives in Gradle layer (not core) so core remains portable.
+ * Path A: [registerTargetPlugin] on existing registered type.
+ * Path B: [deriveTargetType] creates + registers derived type (core + plugins).
+ */
+interface TargetPluginRegistryApi {
+    /** Register/append plugins for the given type (accumulates, dedups by plugin id). */
+    fun register(type: TargetType, plugins: List<TargetPluginSpec>)
+
+    /** Ordered plugins bound to this type (empty if none). */
+    fun get(type: TargetType): List<TargetPluginSpec>
+
+    /** Snapshot for debugging. */
+    fun all(): Map<TargetType, List<TargetPluginSpec>>
+}
+
+class DefaultTargetPluginRegistry : TargetPluginRegistryApi {
+    private val byType = mutableMapOf<TargetType, List<TargetPluginSpec>>()
+
+    override fun register(type: TargetType, plugins: List<TargetPluginSpec>) {
+        if (plugins.isEmpty()) return
+        val existing = byType[type] ?: emptyList()
+        val merged = existing.toMutableList()
+        for (p in plugins) {
+            if (merged.none { it.id == p.id }) {
+                merged += p
+            }
+        }
+        byType[type] = merged
+    }
+
+    override fun get(type: TargetType): List<TargetPluginSpec> = byType[type] ?: emptyList()
+
+    override fun all(): Map<TargetType, List<TargetPluginSpec>> = byType.toMap()
+}
+
+/** Global registry for type → plugin bindings. Same scope as TargetRegistry usage. */
+object TargetPluginRegistry : TargetPluginRegistryApi by DefaultTargetPluginRegistry()
+
+/**
+ * Path A: attach (or accumulate) plugins to an already-registered target type.
+ * From this point, every call site using that type will auto-apply the plugin(s).
+ */
+fun registerTargetPlugin(targetType: TargetType, vararg plugins: TargetPluginSpec) {
+    if (plugins.isNotEmpty()) {
+        TargetPluginRegistry.register(targetType, plugins.toList())
+    }
+}
+
+/**
+ * Path B + general: derive a new TargetType that inherits base's allowed deps + content rules.
+ * - Creates + registers cloned TargetRegistration into the provided coreRegistry (if non-null).
+ * - Attaches the plugin list in TargetPluginRegistry under the derived type.
+ * - Returns the new TargetType (usable for validators and DSLs).
+ *
+ * Callers that want Android semantics pass AndroidTargetRegistry as coreRegistry.
+ */
+fun deriveTargetType(
+    id: String,
+    base: TargetType,
+    nameSuffix: String = base.nameSuffix,
+    plugins: List<TargetPluginSpec> = emptyList(),
+    coreRegistry: TargetRegistry? = null
+): TargetType {
+    val derived = targetType(id, nameSuffix, displayName = id)
+
+    coreRegistry?.let { registry ->
+        val baseReg = registry.all().firstOrNull { it.type.id == base.id }
+        if (baseReg != null) {
+            registry.register(baseReg.copy(type = derived))
+        } else {
+            // Fallback: register minimal so validatorFor etc still work (no allow-list means strict)
+            // but in practice bases are always pre-registered.
+            registry.register(
+                TargetRegistration(
+                    type = derived,
+                    allowedDependencies = emptySet(),
+                    contentRules = emptyList()
+                )
+            )
+        }
+    }
+
+    if (plugins.isNotEmpty()) {
+        registerTargetPlugin(derived, *plugins.toTypedArray())
+    }
+    return derived
+}

--- a/plugins/deps/src/main/java/tools.forma/deps/core/TargetPluginSpec.kt
+++ b/plugins/deps/src/main/java/tools.forma/deps/core/TargetPluginSpec.kt
@@ -1,0 +1,17 @@
+package tools.forma.deps.core
+
+/**
+ * Specification for an external Gradle plugin that is owned by a TargetType.
+ * Registered once against a type (Path A or Path B); auto-applied on every use of that type.
+ * No plugin ids ever appear at call sites.
+ */
+data class TargetPluginSpec(
+    val id: String,
+    val dependencies: FormaDependency = EmptyDependency
+)
+
+/** Factory for a type-owned external plugin spec (id + optional companion deps). */
+fun targetPlugin(
+    id: String,
+    dependencies: FormaDependency = EmptyDependency
+): TargetPluginSpec = TargetPluginSpec(id, dependencies)

--- a/plugins/deps/src/main/java/tools.forma/deps/core/applyTargetPlugins.kt
+++ b/plugins/deps/src/main/java/tools.forma/deps/core/applyTargetPlugins.kt
@@ -1,0 +1,30 @@
+package tools.forma.deps.core
+
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import tools.forma.core.target.TargetType
+import tools.forma.validation.EmptyValidator
+
+/**
+ * Auto-apply any TargetPluginSpec(s) bound to this TargetType.
+ * Call after applyFeatures(...) and before/around applyDependencies.
+ *
+ * Plugins are looked up from the global TargetPluginRegistry (populated via
+ * registerTargetPlugin or deriveTargetType). This is the mechanism that makes
+ * "type owns plugin, call site has zero plugin surface".
+ */
+fun Project.applyTargetPlugins(type: TargetType) {
+    val specs = TargetPluginRegistry.get(type)
+    specs.forEach { spec ->
+        apply(plugin = spec.id)
+        val deps = spec.dependencies
+        // Mirror applyDependencies guard to avoid unnecessary {} block for empty.
+        if (deps !== EmptyDependency && deps != EmptyDependency) {
+            applyDependencies(
+                validator = EmptyValidator,
+                dependencies = deps,
+                repositoriesConfiguration = EmptyRepositoriesConfiguration
+            )
+        }
+    }
+}

--- a/plugins/deps/src/test/kotlin/tools/forma/deps/core/TargetPluginRegistryTest.kt
+++ b/plugins/deps/src/test/kotlin/tools/forma/deps/core/TargetPluginRegistryTest.kt
@@ -1,0 +1,89 @@
+package tools.forma.deps.core
+
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertTrue
+import tools.forma.core.target.DefaultTargetRegistry
+import tools.forma.core.target.TargetRegistration
+import tools.forma.core.target.targetType
+
+/**
+ * F-071: type owns plugins — registry + derive without any call-site plugin API.
+ */
+class TargetPluginRegistryTest {
+
+    @Test
+    fun `DefaultTargetPluginRegistry registers ordered plugins and dedupes by id`() {
+        val registry = DefaultTargetPluginRegistry()
+        val type = targetType("test.res", "res")
+        val first = targetPlugin("plugin.a")
+        val second = targetPlugin("plugin.b")
+        val dup = targetPlugin("plugin.a")
+
+        registry.register(type, listOf(first, second))
+        registry.register(type, listOf(dup, targetPlugin("plugin.c")))
+
+        val ids = registry.get(type).map { it.id }
+        assertEquals(listOf("plugin.a", "plugin.b", "plugin.c"), ids)
+    }
+
+    @Test
+    fun `registerTargetPlugin Path A binds plugins on global registry`() {
+        val type = targetType("test.path-a-${System.nanoTime()}", "res")
+        val plugin = targetPlugin("androidx.navigation.safeargs.kotlin")
+
+        registerTargetPlugin(type, plugin)
+
+        val specs = TargetPluginRegistry.get(type)
+        assertEquals(listOf("androidx.navigation.safeargs.kotlin"), specs.map { it.id })
+        // Call site never passes plugin ids — type lookup is sufficient
+        assertTrue(specs.isNotEmpty())
+    }
+
+    @Test
+    fun `deriveTargetType Path B clones base registration and attaches plugins`() {
+        val core = DefaultTargetRegistry()
+        val base = targetType("test.base-res-${System.nanoTime()}", "res")
+        val allowed = setOf(targetType("test.allowed", "library"))
+        core.register(
+            TargetRegistration(
+                type = base,
+                allowedDependencies = allowed,
+                contentRules = emptyList()
+            )
+        )
+
+        val safeArgs = targetPlugin("androidx.navigation.safeargs.kotlin")
+        val derived = deriveTargetType(
+            id = "test.navigation-res-${System.nanoTime()}",
+            base = base,
+            nameSuffix = "res",
+            plugins = listOf(safeArgs),
+            coreRegistry = core
+        )
+
+        assertEquals("res", derived.nameSuffix)
+        val derivedReg = core.all().firstOrNull { it.type.id == derived.id }
+        assertNotNull(derivedReg)
+        assertEquals(allowed, derivedReg.allowedDependencies)
+
+        val baseReg = core.all().first { it.type.id == base.id }
+        assertEquals(allowed, baseReg.allowedDependencies)
+
+        assertEquals(
+            listOf("androidx.navigation.safeargs.kotlin"),
+            TargetPluginRegistry.get(derived).map { it.id }
+        )
+        // Base type has no plugins unless Path A registered them
+        assertTrue(TargetPluginRegistry.get(base).isEmpty())
+    }
+
+    @Test
+    fun `empty plugin list leaves type unbound`() {
+        val registry = DefaultTargetPluginRegistry()
+        val type = targetType("test.empty", "impl")
+        registry.register(type, emptyList())
+        assertTrue(registry.get(type).isEmpty())
+    }
+}


### PR DESCRIPTION
## Summary
Implements **F-071** (P7): type owns external Gradle plugins; call sites stay attributes-only.

- `TargetPluginSpec` / `targetPlugin` factory
- `TargetPluginRegistry` + Path A `registerTargetPlugin` + Path B `deriveTargetType` (clones base registration)
- `Project.applyTargetPlugins(type)` after `applyFeatures` on **all** Android target DSLs
- Unit tests prove registry/Path A/B without call-site plugin API
- Legacy `TargetBuilder.withPlugin` / sample unchanged (F-072)

## Verify
- `plugins/ ./gradlew build` → BUILD SUCCESSFUL
- `application/ ./gradlew help` → BUILD SUCCESSFUL

## Next
F-072: migrate sample to `navigationRes` (derived type); deprecate chain API.