### PR TITLE
F-082: single androidProjectConfiguration path; extraPlugins classpath-only

### DIFF
--- a/README.md
+++ b/README.md
@@ -86,6 +86,8 @@ buildscript {
         targetSdk = 33,
         compileSdk = 34,
         agpVersion = "8.13.2",
+        // extraPlugins = buildscript classpath only (jars for AGP, safe-args, etc.).
+        // Actual plugin apply to targets is type-owned — see docs/TARGET-PLUGINS.md.
         extraPlugins = listOf(
             "androidx.navigation:navigation-safe-args-gradle-plugin:2.7.4",
             "com.google.firebase:firebase-crashlytics-gradle:2.9.9",

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -98,14 +98,14 @@ Close the biggest call-site / multi-way gap: chain `withPlugin`. Design:
 ## P8 — Principle alignment (implementation matches goals)
 
 Close remaining gaps where code/docs still allow **multiple ways**, **fat call
-sites**, or **missing fleet tooling**. P7 (F-070–F-073) and F-081 are **done**;
-next coding priority is **F-082**.
+sites**, or **missing fleet tooling**. P7 (F-070–F-073) and F-081–F-082 are **done**;
+next coding priority is **F-083**.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
 | F-080 | done | Codify root principles in product docs | `VISION.md` § Root principles + README + `AGENTS.md` + GETTING-STARTED; board P8 added |
 | F-081 | done | Call-site surface audit: `Unit` returns, no builder chains, minimal attrs | Hard-removed `TargetBuilder` / `PluginWrapper` / sample `Plugins` + chain-only `PluginConfiguration`; all Android/JVM DSLs already `Unit`; `docs/CALL-SITE-SURFACE.md` flag inventory (`compose` → project-global default, `viewBinding` on impl + dedicated type) |
-| F-082 | todo | One global configuration path | Remove/finish-kill deprecated `Project.androidProjectConfiguration`; document `extraPlugins` as **classpath only** (not per-module apply); single settings/store story |
+| F-082 | done | One global configuration path | Hard-removed `Project.androidProjectConfiguration`; `ScriptHandlerScope` form is the single API; `extraPlugins` documented classpath-only; new `PROJECT-CONFIGURATION.md` + cross-links; builds green |
 | F-083 | todo | One project-global external-deps convention | House style: version catalog **or** typed catalogs as the sample+docs standard; other path = advanced/legacy note, not dual happy path (`DEPS-CATALOG.md`) |
 | F-084 | todo | Fleet tooling for explicit graphs (check / generate / migrate) | Principle 3 at scale: tighten includer/depgen/bazel-check; design+spike migrate helpers for renames/type changes; related GH **#54**. Reliable large refactors without hand-editing thousands of modules |
 | F-085 | todo | Full-tree principle audit: sample + examples + agent skills | After F-072/F-081: no chain APIs, no dual styles taught, call sites minimal; fix stragglers |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -257,11 +257,23 @@ Wiring pattern:
 Root configuration (`application/build.gradle.kts`):
 
 ```kotlin
-androidProjectConfiguration(
-  minSdk = 21, targetSdk = 33, compileSdk = 34,
-  agpVersion = "8.13.2",
-  extraPlugins = [ demo deps, KSP, nav safe-args, crashlytics ]
-)
+// ScriptHandlerScope form inside buildscript { } is the single supported path (F-082).
+// extraPlugins puts jars on the buildscript classpath only.
+buildscript {
+    androidProjectConfiguration(
+        project = rootProject,
+        minSdk = 23,
+        targetSdk = 35,
+        compileSdk = 35,
+        agpVersion = "8.13.2",
+        extraPlugins = listOf(
+            // classpath only — see PROJECT-CONFIGURATION.md + TARGET-PLUGINS.md
+            libs.plugins.toolsFormaDemoDependencies,
+            libs.plugins.navigationSafeArgs,
+            // ...
+        )
+    )
+}
 ```
 
 ---

--- a/docs/CALL-SITE-SURFACE.md
+++ b/docs/CALL-SITE-SURFACE.md
@@ -90,6 +90,6 @@ parameters beside them.
 - Principles: [VISION.md](VISION.md) § Root principles  
 - Matrix: [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md)  
 - Plugins: [TARGET-PLUGINS.md](TARGET-PLUGINS.md)  
-- Global config cleanup (single settings path): **F-082**  
+- Global config (one path + store story): [`PROJECT-CONFIGURATION.md`](PROJECT-CONFIGURATION.md) (F-082)
 - House style for external deps catalogs: **F-083**  
 - Full-tree teaching audit: **F-085**

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -176,9 +176,11 @@ buildscript {
 }
 ```
 
-This stores shared Android settings, puts AGP (and optional **plugin jars**) on
-the buildscript classpath, and registers a root `clean` task. Child targets read
-these values automatically.
+This stores shared Android settings (`AndroidProjectSettings` via `Forma` / `FormaSettingsStore`),
+puts AGP + optional plugin jars on the **buildscript classpath only**, and registers a root
+`clean` task. Child targets read values from `Forma.settings`.
+
+See [`PROJECT-CONFIGURATION.md`](PROJECT-CONFIGURATION.md) for the single-path + store story.
 
 ### External Gradle plugins (safe-args, Firebase, …)
 
@@ -451,6 +453,7 @@ Details: [COMPOSE.md](COMPOSE.md). Sample:
 | [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md) | Allowed project-dep edges (code truth) |
 | [DEPS-CATALOG.md](DEPS-CATALOG.md) | External catalogs (`library`, `bundle`, `plugin`) |
 | [COMPOSE.md](COMPOSE.md) | Compose flags + `composeWidget` |
+| [PROJECT-CONFIGURATION.md](PROJECT-CONFIGURATION.md) | One global config path + settings store (F-082) |
 | [ENV.md](ENV.md) | JDK / SDK bootstrap |
 | [ARCHITECTURE.md](ARCHITECTURE.md) | Monorepo + plugin module graph |
 | [VISION.md](VISION.md) | forma-core → JVM → Bazel roadmap |

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,29 @@
 
 Newest entries first.
 
+## 2026-07-20 — F-082: One global configuration path
+
+- **Ticket:** F-082 → `done`
+- **Branch:** `forma/F-082-global-config-path` (from origin/v2)
+- **Skills/modes:** /goal + todo_write + explore before edits; product code first (compile green) then docs; self-verify planned with /check-work
+- **Code:**
+  - Hard-removed `fun Project.androidProjectConfiguration(...)` (and its dead params `dataBinding`/`validateManifestPackages`/`generateMissedManifests`) from `plugins/android/src/main/java/androidProjectConfiguration.kt`
+  - Replaced imprecise KDoc; `ScriptHandlerScope.androidProjectConfiguration` now clearly documents: single supported path, `extraPlugins` = **buildscript classpath only**, points to `TARGET-PLUGINS.md` for apply, `Forma`/`FormaSettingsStore`/`AndroidProjectSettings` store story, "do not call from arbitrary Project scopes"
+  - No remaining references or call sites to the removed overload (verified by grep)
+- **Docs:**
+  - New `docs/PROJECT-CONFIGURATION.md` — one path, what the call does (classpath + store + registry), what it does not (apply), removed overload, single settings/store story table, pointers + checklist
+  - README: added classpath-only comment on `extraPlugins` sample
+  - CALL-SITE-SURFACE.md: marked F-082 done + link to PROJECT-CONFIGURATION
+  - GETTING-STARTED.md: link to new doc; clarified store behavior
+  - ARCHITECTURE.md: updated root config snippet with `project=`, `buildscript`, classpath note
+  - TARGET-PLUGINS.md: reinforced classpath story + cross link
+- **No dual path** in examples/agent-skills (scanned; all usage already correct `buildscript` form; no "old approach" language)
+- **Verify (real host, `source scripts/env-mac.sh`):**
+  - `plugins/ ./gradlew build --console=plain` → **BUILD SUCCESSFUL** (78 tasks)
+  - `application/ ./gradlew build --console=plain` → **BUILD SUCCESSFUL** (2554 tasks, 3m56s)
+- **Blockers:** none
+- **Next:** F-083 one external-deps house style
+
 ## 2026-07-20 — F-081: call-site surface audit + hard-remove chain API
 
 - **Ticket:** F-081 → `done`

--- a/docs/PROJECT-CONFIGURATION.md
+++ b/docs/PROJECT-CONFIGURATION.md
@@ -1,0 +1,90 @@
+# Project configuration (F-082)
+
+**One global configuration path only.**
+
+Forma has a single supported entry point for Android project-wide settings and classpath:
+
+```kotlin
+// root build.gradle.kts
+buildscript {
+    androidProjectConfiguration(
+        project = rootProject,
+        minSdk = 23,
+        targetSdk = 35,
+        compileSdk = 35,
+        agpVersion = "8.13.2",
+        // compose = false,
+        // composeCompilerVersion = "2.0.21",
+        extraPlugins = listOf(
+            // jars / Provider<PluginDependency> for the *buildscript classpath only*
+            libs.plugins.navigationSafeArgs,
+            // ...
+        )
+    )
+}
+```
+
+This is the **only** supported way to configure an Android Forma project.
+
+## What `androidProjectConfiguration` does
+
+- **Classpath**: Adds the requested AGP version, the Kotlin Compose compiler Gradle plugin (when relevant), and any `extraPlugins` entries to the root **buildscript classpath**.
+- **Settings store**: Creates an `AndroidProjectSettings` and writes it via `Forma.store(...)`, which delegates to the singleton `FormaSettingsStore`.
+- **Target registry**: Calls `registerAndroidDefaults()` so that all Android target types + restriction matrix + content rules are available to DSL call sites.
+- **Convenience**: Registers a conventional root `clean` task.
+
+Downstream targets and features read global values (SDK versions, `compose` default, `kotlinVersion`, `agpVersion`, etc.) from `Forma.settings` (or the delegated store surfaces). The store is initialized exactly once from the root `buildscript` block.
+
+## What it does **not** do
+
+- `extraPlugins` (and catalog `plugin(...)` entries) are **classpath only**. They put Gradle plugin jars on the buildscript classpath. They do **not** apply any plugin to your modules.
+- Applying plugins to targets is handled exclusively by the **type-owned plugin registry**:
+  - Register once with `targetPlugin(...)` + `deriveTargetType(...)` (Path B, preferred) or `registerTargetPlugin(...)` (Path A).
+  - The registry auto-applies on matching DSL calls.
+  - See [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md).
+
+There is no per-module `withPlugin`, no free-form `plugins =` lists, and no second configuration path.
+
+## Removed (F-082)
+
+The deprecated `Project.androidProjectConfiguration(...)` receiver overload has been **hard-removed**.
+
+- It was the "call configuration from any module" dual happy path.
+- All live call sites already used the `ScriptHandlerScope` form inside root `buildscript { }`.
+- Do not attempt to configure from arbitrary `Project` scopes. Configuration belongs at the root buildscript level.
+
+## The single settings / store story
+
+| Piece | Location | Role |
+|-------|----------|------|
+| `androidProjectConfiguration(...)` (ScriptHandlerScope) | `plugins/android/.../androidProjectConfiguration.kt` | The one public API; called from root `buildscript` |
+| `AndroidProjectSettings` | `plugins/config/.../AndroidProjectSettings.kt` | Immutable data class holding SDKs, versions, compose default, repos, etc. |
+| `FormaSettingsStore` | `plugins/config/.../AndroidProjectSettings.kt` (as `object`) | The backing singleton store (`SettingsStore<T>` + `PluginInfoStore`) |
+| `Forma` (singleton accessor) | `plugins/android/.../androidProjectConfiguration.kt` | `object Forma : SettingsStore<...> by FormaSettingsStore, ...` — primary reader surface (`Forma.settings`) |
+| `registerAndroidDefaults()` | `plugins/android/.../AndroidTargetRegistry.kt` | Populates `AndroidTargetRegistry` (target types + matrix) |
+
+Readers (feature wiring, dependency helpers, target DSLs) obtain values through `Forma.settings` after the root configuration has run. The store is the single source of truth for the project-global Android configuration.
+
+## Cross references
+
+- [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) — classpath (`extraPlugins`) vs. type-owned apply
+- [`CALL-SITE-SURFACE.md`](CALL-SITE-SURFACE.md) — F-081 / F-082 surface rules (no chains, minimal attrs, global config)
+- [`GETTING-STARTED.md`](GETTING-STARTED.md) — tutorial usage + checklist
+- [`COMPOSE.md`](COMPOSE.md) — `compose` + `composeCompilerVersion` details
+- [`ARCHITECTURE.md`](ARCHITECTURE.md) — plugin module layout and store
+- [`VISION.md`](VISION.md) — root principles (one global way)
+- Sample: `application/build.gradle.kts`
+- Progressive example 10: `examples/android/10-target-plugins`
+
+## Checklist — correct global configuration
+
+- [ ] Exactly one `androidProjectConfiguration(...)` call in the **root** `buildscript { }`
+- [ ] `project = rootProject` (or equivalent root)
+- [ ] `extraPlugins` only for classpath jars (see TARGET-PLUGINS for how to actually apply)
+- [ ] No calls to any `Project.androidProjectConfiguration` form (removed)
+- [ ] Child targets rely on `Forma.settings` / per-target overrides only
+- [ ] Type-owned plugins used for external plugin application (no ad-hoc apply)
+
+---
+
+F-082 completes the "one global way" cleanup for project configuration (paired with F-081 call-site surface work).

--- a/docs/TARGET-PLUGINS.md
+++ b/docs/TARGET-PLUGINS.md
@@ -7,7 +7,7 @@ target kind + attributes. Plugin identity is part of the **rule / target type**,
 not restated on every module. Extending a type with a plugin **auto-applies** that
 plugin on every call site of that type.
 
-**Status:** F-070–F-073 **shipped** on `v2`. Registry + auto-apply · sample `navigationRes` Path B · user docs + progressive example `examples/android/10-target-plugins` + agent skill `forma-target-plugins` · GH #36 closed. **F-081:** chain API **hard-removed** (`TargetBuilder` / `PluginWrapper` / sample `Plugins`) — see [`CALL-SITE-SURFACE.md`](CALL-SITE-SURFACE.md).
+**Status:** F-070–F-073 **shipped** on `v2`. Registry + auto-apply · sample `navigationRes` Path B · user docs + progressive example `examples/android/10-target-plugins` + agent skill `forma-target-plugins` · GH #36 closed. **F-081:** chain API **hard-removed**. **F-082:** single `androidProjectConfiguration` path (classpath-only `extraPlugins`) — see [`PROJECT-CONFIGURATION.md`](PROJECT-CONFIGURATION.md) and [`CALL-SITE-SURFACE.md`](CALL-SITE-SURFACE.md).
 
 **Related:** [`DEPS-CATALOG.md`](DEPS-CATALOG.md), [`ARCHITECTURE.md`](ARCHITECTURE.md),
 [`forma-core-api.md`](forma-core-api.md), `TargetRegistry` / `TargetRegistration`.
@@ -16,6 +16,7 @@ plugin on every call site of that type.
 ## Quick start (users)
 
 1. Put the Gradle plugin jar on the **classpath** (`extraPlugins` / catalog `plugin(...)`).
+   See [`PROJECT-CONFIGURATION.md`](PROJECT-CONFIGURATION.md) — `extraPlugins` is buildscript-classpath only.
 2. Bind the plugin to a **type** once:
    - **Path B (typical):** `targetPlugin` + `deriveTargetType` + thin DSL (see sample `NavigationRes.kt` / example `forma-defs/`).
    - **Path A:** `registerTargetPlugin(AndroidTargetTypes.res, …)` only if *every* module of that kind should get it.
@@ -23,6 +24,8 @@ plugin on every call site of that type.
 
 Hands-on: [`examples/android/10-target-plugins`](../examples/android/10-target-plugins).  
 Agent skill: [`forma-target-plugins`](../examples/agent-skills/forma-target-plugins.md).
+
+Global configuration lives at root `buildscript { androidProjectConfiguration(...) }` (F-082).
 
 ---
 

--- a/plugins/android/src/main/java/androidProjectConfiguration.kt
+++ b/plugins/android/src/main/java/androidProjectConfiguration.kt
@@ -14,20 +14,58 @@ import tools.forma.config.FormaSettingsStore
 import tools.forma.config.PluginInfoStore
 import tools.forma.config.SettingsStore
 
-// TODO: add docs for every fun param
 /**
- * Configures common values for whole forma modules.
+ * The **single supported entry point** for Android project-wide configuration in Forma.
  *
- * @param minSdk is min android sdk
- * @param targetSdk is target android sdk
- * @param compileSdk SDK version used to compile Android App
- * @param repositories is a function that configures repositories for project
- * @param javaVersionCompatibility is a java version that will be used for targetCompatibility and
- *   sourceCompatibility versions
- * @param mandatoryOwners is a flag that enables mandatory owners for all modules
+ * Call this exactly once from the **root** `build.gradle.kts` inside a `buildscript { }` block:
+ *
+ * ```kotlin
+ * buildscript {
+ *     androidProjectConfiguration(
+ *         project = rootProject,
+ *         minSdk = 23,
+ *         targetSdk = 35,
+ *         compileSdk = 35,
+ *         agpVersion = "8.13.2",
+ *         // ...
+ *     )
+ * }
+ * ```
+ *
+ * What it does:
+ * - Puts AGP + (when relevant) the Kotlin Compose compiler Gradle plugin on the **buildscript classpath**.
+ * - Adds any `extraPlugins` **jars / providers to the buildscript classpath only**.
+ * - Stores [AndroidProjectSettings] via [Forma.store] (delegates to [FormaSettingsStore]).
+ *   Downstream targets read global values from `Forma.settings`.
+ * - Registers default Android target types and restriction matrix via [registerAndroidDefaults].
+ * - Registers a conventional root `clean` task.
+ *
+ * **extraPlugins**:
+ * Jars (or `Provider<PluginDependency>`) listed here are added to the root **buildscript classpath**.
+ * They do **NOT** cause any plugin to be applied to modules.
+ * To actually apply an external Gradle plugin to targets, register it against a target type
+ * using the type-owned plugin APIs and let the registry auto-apply it:
+ * see [docs/TARGET-PLUGINS.md](TARGET-PLUGINS.md) (`targetPlugin`, `deriveTargetType`,
+ * `registerTargetPlugin`, Path A vs Path B).
+ *
+ * This is the **only** supported project configuration path. The previous `Project` receiver
+ * overload has been removed (F-082). Do not call configuration from arbitrary `Project` scopes.
+ *
+ * @param project the root project (typically `rootProject`); used to register the clean task.
+ * @param minSdk minimum Android SDK
+ * @param targetSdk target Android SDK
+ * @param compileSdk SDK version used to compile Android targets
+ * @param kotlinVersion Kotlin version (defaults to Gradle's embeddedKotlinVersion)
+ * @param agpVersion Android Gradle Plugin version to place on the buildscript classpath
+ * @param repositories optional block to configure repositories (applied in buildscript context)
  * @param compose project-wide default for per-target Compose flags (see [AndroidProjectSettings.compose])
  * @param composeCompilerVersion Compose compiler extension version for AGP `composeOptions`
- * @param extraPlugins is a list of extra plugins that will be applied to project
+ *   (must match the Kotlin version used)
+ * @param javaVersionCompatibility Java language level for source/target compatibility
+ * @param mandatoryOwners when true, all targets require an owner declaration
+ * @param vectorDrawablesUseSupportLibrary passed through to Android vector drawable config
+ * @param extraPlugins list of extra artifacts / plugin providers to add to the **buildscript classpath only**.
+ *   See "Classpath vs apply" in TARGET-PLUGINS.md.
  */
 fun ScriptHandlerScope.androidProjectConfiguration(
     project: Project,
@@ -81,48 +119,6 @@ fun ScriptHandlerScope.androidProjectConfiguration(
     registerAndroidDefaults()
 }
 
-@Deprecated("Old approach to configuration, use ScriptHandlerScope Extension")
-fun Project.androidProjectConfiguration(
-    minSdk: Int,
-    targetSdk: Int,
-    compileSdk: Int,
-    kotlinVersion: String,
-    agpVersion: String,
-    repositories: RepositoryHandler.() -> Unit = {},
-    dataBinding: Boolean = false,
-    validateManifestPackages: Boolean = false,
-    generateMissedManifests: Boolean = false,
-    javaVersionCompatibility: JavaVersion = JavaVersion.VERSION_1_8, // Java/Kotlin configuration
-    mandatoryOwners: Boolean = false,
-    compose: Boolean = false,
-    composeCompilerVersion: String = DEFAULT_COMPOSE_COMPILER_VERSION,
-    vectorDrawablesUseSupportLibrary: Boolean = true,
-) {
-
-    /** Default Android project clean task implementation */
-    tasks.register("clean", Delete::class) { delete(project.layout.buildDirectory) }
-
-    val configuration =
-        AndroidProjectSettings(
-            minSdk = minSdk,
-            targetSdk = targetSdk,
-            compileSdk = compileSdk,
-            // we don't need check properties for exist, we read it successfully in forma
-            // configuration
-            kotlinVersion = kotlinVersion,
-            agpVersion = agpVersion,
-            repositories = repositories,
-            javaVersionCompatibility = javaVersionCompatibility,
-            mandatoryOwners = mandatoryOwners,
-            compose = compose,
-            composeCompilerVersion = composeCompilerVersion,
-            vectorDrawablesUseSupportLibrary = vectorDrawablesUseSupportLibrary
-        )
-
-    Forma.store(configuration)
-    registerAndroidDefaults()
-}
-
 /** Compose Compiler matching Kotlin 2.0.21 (Gradle 8.14.5 embedded Kotlin). */
 const val DEFAULT_COMPOSE_COMPILER_VERSION = "2.0.21"
 
@@ -146,7 +142,16 @@ val buildScriptConfiguration: ScriptHandlerScope.(List<Any>) -> Unit = { classpa
     }
 }
 
-/** Singleton project configuration store TODO remove */
+/**
+ * Singleton accessor for stored project configuration.
+ *
+ * Delegates to [FormaSettingsStore] (which holds the single [AndroidProjectSettings] instance
+ * written by [androidProjectConfiguration]).
+ *
+ * Downstream code and targets obtain values via `Forma.settings` (or the delegated
+ * `SettingsStore` / `PluginInfoStore` surfaces). There is exactly one global configuration
+ * story: root `buildscript { androidProjectConfiguration(...) }` → store → readers.
+ */
 object Forma :
     SettingsStore<AndroidProjectSettings> by FormaSettingsStore,
     PluginInfoStore by FormaSettingsStore


### PR DESCRIPTION
## Summary
F-082: one global Android project configuration path.

- **Hard-remove** deprecated `Project.androidProjectConfiguration` (dead dual path; zero call sites).
- **KDoc** on remaining `ScriptHandlerScope.androidProjectConfiguration`: only supported entry point; `extraPlugins` = **buildscript classpath only** (does not apply plugins).
- New `docs/PROJECT-CONFIGURATION.md` — single path + `Forma` / `FormaSettingsStore` / `AndroidProjectSettings` story.
- Cross-links: README, GETTING-STARTED, ARCHITECTURE, CALL-SITE-SURFACE, TARGET-PLUGINS, TICKETS/PROGRESS.

## Verify (host)
- `plugins/ ./gradlew build` → BUILD SUCCESSFUL (78 tasks)
- `application/ ./gradlew build` → BUILD SUCCESSFUL (2554 tasks)

## Next
F-083 — one project-global external-deps house style.