### PR TITLE
F-019: Gradle 9.6.1 + Kotlin 2.3.21 + AGP 9.3.0

### DIFF
--- a/README.md
+++ b/README.md
@@ -85,7 +85,7 @@ buildscript {
         minSdk = 21,
         targetSdk = 33,
         compileSdk = 34,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
         // extraPlugins = buildscript classpath only (jars for AGP, safe-args, etc.).
         // Actual plugin apply to targets is type-owned — see docs/TARGET-PLUGINS.md.
         extraPlugins = listOf(

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -22,7 +22,8 @@ Canonical write-up: `docs/VISION.md` § Root principles. Plugins design: `docs/T
 | F-002 | done | Audit build graph: plugins, sample app, CI workflows | Map modules → forma-core candidates; capture in `docs/ARCHITECTURE.md` |
 | F-003 | done | Get plugins + sample `application/` building on modern toolchain | Plugins compile AGP 8.1.2 matches sample; Gradle 8.3 (plugins) / 8.4 (app); host builds green |
 | F-004 | done | CI green on GitHub Actions for plugins + application | Temurin 17 all jobs + Android SDK 33 for app; PR #153 GHA green |
-| F-018 | done | JDK 21 + Gradle/AGP staged modernization | **Shipped on `v2`:** Gradle **8.14.5**, AGP **8.13.2**, Kotlin **2.0.21**, KSP **2.0.21-1.0.28**, Compose **1.9.4**/compiler **2.0.21**, JDK **21** host/CI, sample SDK min23/target35/compile35 + deps at AGP-8.13 ceiling. PRs **#179–#182**. AGP 9 / absolute-latest AndroidX = **F-019** (explicit OK only). |
+| F-018 | done | JDK 21 + Gradle/AGP staged modernization | **Shipped on `v2`:** Gradle **8.14.5**, AGP **8.13.2**, Kotlin **2.0.21**, KSP **2.0.21-1.0.28**, Compose **1.9.4**/compiler **2.0.21**, JDK **21** host/CI, sample SDK min23/target35/compile35 + deps at AGP-8.13 ceiling. PRs **#179–#182**. Superseded by **F-019** for 9.x. |
+| F-019 | done | Gradle 9 + Kotlin 2.3 + AGP 9 toolchain | **Shipped Phase 1:** Gradle **9.6.1** (embedded Kotlin **2.3.21**), AGP **9.3.0**, KSP **2.3.10**, Compose compiler **2.3.21**, aapt2-proto **9.3.0-15703166**, Dagger **2.60.1**. Sample uses `android.builtInKotlin=false` + `android.newDsl=false` (kapt/Dagger still). **Phase 2 backlog:** built-in Kotlin + kapt→KSP + AndroidX ceiling. |
 
 ## P1 — Android working product
 
@@ -98,8 +99,8 @@ Close the biggest call-site / multi-way gap: chain `withPlugin`. Design:
 ## P8 — Principle alignment (implementation matches goals)
 
 Close remaining gaps where code/docs still allow **multiple ways**, **fat call
-sites**, or **missing fleet tooling**. P7 (F-070–F-073) and F-081–F-082 are **done**;
-next coding priority is **F-083**.
+sites**, or **missing fleet tooling**. P7 (F-070–F-073) and F-081–F-082 are **done**; **F-019 Phase 1 done**.
+**Next coding:** **F-083**.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
@@ -127,7 +128,7 @@ Keep for reference; do not start unless higher tickets done or user prioritizes:
 - GH #126 Target features configuration options → consider under **F-081**
 - GH #111 Gradle project as buildscript classpath
 - GH #103 Java 8+ API on Android API ≤26
-- **F-019** AGP 9 / absolute-latest AndroidX — **explicit OK only** (not on board until requested)
+- F-019 Phase 2: AGP built-in Kotlin migration + absolute-latest AndroidX / compileSdk bump (after Phase 1 green)
 
 ## How workers update this file
 

--- a/application/build.gradle.kts
+++ b/application/build.gradle.kts
@@ -5,7 +5,7 @@ buildscript {
         targetSdk = 35,
         // compileSdk 35+ required by Compose 1.11 / modern AndroidX AAR metadata
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
         extraPlugins =
             listOf(
                 libs.plugins.toolsFormaDemoDependencies,

--- a/application/feature/characters/favorite/impl/src/main/java/tools/forma/sample/feature/characters/favorite/impl/ui/CharacterFavoriteFragment.kt
+++ b/application/feature/characters/favorite/impl/src/main/java/tools/forma/sample/feature/characters/favorite/impl/ui/CharacterFavoriteFragment.kt
@@ -27,6 +27,7 @@ import tools.forma.sample.core.di.library.BaseComponentProvider
 import tools.forma.sample.core.mvvm.library.ui.BaseViewBindingFragment
 import tools.forma.sample.core.mvvm.library.viewModels
 import tools.forma.sample.feature.characters.core.api.domain.model.ICharacter
+import tools.forma.sample.feature.characters.favorite.impl.presentation.CharacterFavoriteViewModel
 import tools.forma.sample.feature.characters.favorite.viewbinding.presentation.ICharacterFavoriteViewModel
 import tools.forma.sample.feature.characters.favorite.viewbinding.presentation.ICharacterFavoriteViewState
 import tools.forma.sample.feature.characters.favorite.impl.R
@@ -39,7 +40,7 @@ class CharacterFavoriteFragment : BaseViewBindingFragment(
     layoutId = tools.forma.sample.feature.characters.favorite.viewbinding.R.layout.fragment_character_favorite_list
 ) {
 
-    private val viewModel: ICharacterFavoriteViewModel by viewModels()
+    private val viewModel: ICharacterFavoriteViewModel by viewModels<CharacterFavoriteViewModel>()
     private val viewBinding: FragmentCharacterFavoriteListBinding by viewBinding(FragmentCharacterFavoriteListBinding::bind)
 
     private val viewAdapter = CharacterFavoriteAdapter()

--- a/application/gradle.properties
+++ b/application/gradle.properties
@@ -26,5 +26,8 @@ org.gradle.unsafe.configuration-cache=true
 org.gradle.unsafe.configuration-cache-problems=warn
 org.gradle.unsafe.configuration-cache.max-problems=5
 # TODO apply via forma
-android.defaults.buildfeatures.buildconfig=false
 android.nonTransitiveRClass=true
+# F-019 Phase 1: AGP 9 + Gradle 9 while sample still uses kapt (Dagger).
+# Built-in Kotlin + new DSL require kapt→KSP migration (Phase 2).
+android.builtInKotlin=false
+android.newDsl=false

--- a/application/gradle/wrapper/gradle-wrapper.properties
+++ b/application/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/application/settings.gradle.kts
+++ b/application/settings.gradle.kts
@@ -38,18 +38,36 @@ buildscript {
                     "org.checkerframework:checker-qual:3.43.0",
                     "com.google.errorprone:error_prone_annotations:2.28.0",
                     "commons-codec:commons-codec:1.17.1",
-                    "com.android.tools.build:aapt2-proto:8.13.2-14304508",
-                    // Gradle 8.14.5 embeds Kotlin 2.0.21 — force stdlib family lockstep under failOnVersionConflict
+                    "com.android.tools.build:aapt2-proto:9.3.0-15703166",
+                    // Gradle 9.6.1 embeds Kotlin 2.3.21 — force stdlib + KGP family lockstep under failOnVersionConflict
+                    // (AGP 9.3 pulls kotlin-stdlib 2.2.10 transitively)
                     "org.jetbrains.kotlin:kotlin-stdlib:$embeddedKotlinVersion",
                     "org.jetbrains.kotlin:kotlin-stdlib-jdk7:$embeddedKotlinVersion",
                     "org.jetbrains.kotlin:kotlin-stdlib-jdk8:$embeddedKotlinVersion",
                     "org.jetbrains.kotlin:kotlin-stdlib-common:$embeddedKotlinVersion",
                     "org.jetbrains.kotlin:kotlin-reflect:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-gradle-plugin:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-gradle-plugin-api:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-gradle-plugins-bom:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:fus-statistics-gradle-plugin:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-compiler-embeddable:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-android-extensions-runtime:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-build-tools-api:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-build-tools-impl:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-build-tools-compat:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-native-utils:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-util-klib:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-util-io:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-daemon-embeddable:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-script-runtime:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-scripting-common:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-scripting-jvm:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-scripting-compiler-embeddable:$embeddedKotlinVersion",
+                    "org.jetbrains.kotlin:kotlin-scripting-compiler-impl-embeddable:$embeddedKotlinVersion",
                     "org.jetbrains.kotlinx:kotlinx-coroutines-core:1.10.2",
                     "org.jetbrains.kotlinx:kotlinx-coroutines-core-jvm:1.10.2",
                     "org.jetbrains.kotlinx:kotlinx-coroutines-android:1.10.2",
-                    "com.android.tools.build:gradle:8.13.2",
-                    "org.jetbrains.kotlin:kotlin-gradle-plugin:$embeddedKotlinVersion",
+                    "com.android.tools.build:gradle:9.3.0",
                     "com.squareup:javapoet:1.13.0"
                 )
                 failOnVersionConflict()
@@ -101,8 +119,8 @@ projectDependencies(
     plugin("com.google.firebase:firebase-crashlytics-gradle", "3.0.7"),
     plugin(
         id = "com.google.devtools.ksp:symbol-processing-gradle-plugin",
-        // Gradle 8.14.5 embeds Kotlin 2.0.21; KSP must match
-        version = "2.0.21-1.0.28",
+        // Gradle 9.6.1 embeds Kotlin 2.3.21; KSP 2.3.x line (standalone numbering)
+        version = "2.3.10",
         configuration = ksp,
         "androidx.room:room-compiler:$roomVersion"
     )

--- a/bazel-adapter/gradle/wrapper/gradle-wrapper.properties
+++ b/bazel-adapter/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/bazel-adapter/settings.gradle.kts
+++ b/bazel-adapter/settings.gradle.kts
@@ -8,9 +8,9 @@ pluginManagement {
         gradlePluginPortal()
         mavenCentral()
     }
-    // Match Gradle 8.14.5 embedded Kotlin
+    // Match Gradle 9.6.1 embedded Kotlin
     plugins {
-        id("org.jetbrains.kotlin.jvm") version "2.0.21"
+        id("org.jetbrains.kotlin.jvm") version "2.3.21"
     }
 }
 

--- a/build-dependencies/dependencies/src/main/kotlin/Androidx.kt
+++ b/build-dependencies/dependencies/src/main/kotlin/Androidx.kt
@@ -302,7 +302,7 @@ object androidx {
     /**
      * Jetpack Compose runtime + UI + foundation + material (pinned versions).
      * Pair with `compose = true` / `composeWidget` targets (F-013).
-     * Versions match Compose Compiler **2.0.21** / Kotlin **2.0.21** (Gradle 8.14.5).
+     * Versions match Compose Compiler **2.3.21** / Kotlin **2.3.21** (Gradle 9.6.1).
      * Uses [transitiveDeps] so Compose UI unit/graphics transitively resolve.
      * Does not include activity-compose (pulls emoji2 requiring compileSdk 34);
      * add that separately when hosting Compose in Activities on SDK 34+.

--- a/build-dependencies/dependencies/src/main/kotlin/Versions.kt
+++ b/build-dependencies/dependencies/src/main/kotlin/Versions.kt
@@ -2,13 +2,13 @@ object versions {
     const val coil = "2.7.0"
 
     object jetbrains {
-        // Last line friendly with Kotlin 2.0.21 + AndroidX caps below
+        // Last line friendly with Kotlin 2.3.21 + AndroidX caps below
         const val coroutines = "1.10.2"
     }
 
     object androidx {
-        // Caps: latest that stay on AGP 8.13 + compileSdk 35
-        // (core 1.17+/activity 1.12+/lifecycle-compose 2.11+ need AGP 9.1 + SDK 36/37)
+        // Caps: latest that stay on AGP 9.3 + compileSdk 35
+        // (core 1.17+/activity 1.12+/lifecycle-compose 2.11+ may need higher SDK / AGP line)
         const val activity = "1.10.1"
         const val annotation = "1.9.1"
         const val arch = "2.2.0"
@@ -43,13 +43,13 @@ object versions {
         const val vectordrawable = "1.2.0"
         const val versionedparcelable = "1.2.1"
         const val viewpager = "1.1.0"
-        // Compose 1.9.x works with AGP 8.6+ / compileSdk 35 / Kotlin 2.0.21
+        // Compose 1.9.x works with AGP 9.3 + compileSdk 35 + Kotlin 2.3.21
         const val compose = "1.9.4"
     }
 
     object google {
         const val material = "1.13.0"
-        const val dagger = "2.56.2"
+        const val dagger = "2.60.1"
         const val play_core = "1.10.3"
         const val gson = "2.13.2"
     }

--- a/build-dependencies/gradle/wrapper/gradle-wrapper.properties
+++ b/build-dependencies/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/build-settings/gradle/wrapper/gradle-wrapper.properties
+++ b/build-settings/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/depgen/gradle/wrapper/gradle-wrapper.properties
+++ b/depgen/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -16,11 +16,11 @@ that compose via `includeBuild`:
 
 | Path | Role | Gradle wrapper | Publishes / consumed as |
 |------|------|----------------|-------------------------|
-| `plugins/` | Forma Gradle plugins (main product) | 8.14.5 | Composite + Plugin Portal (`tools.forma.*`) |
-| `application/` | Sample Android product (gold standard) | 8.14.5 | Consumer only |
-| `jvm-application/` | Sample pure-JVM product (`tools.forma.jvm`) | 8.14.5 | Consumer only |
-| `includer/` | Settings plugin: auto-`include` subprojects | 8.14.5 | `tools.forma.includer` |
-| `depgen/` | Transitive-deps generation plugin | 8.14.5 | `tools.forma.depgen` (standalone) |
+| `plugins/` | Forma Gradle plugins (main product) | 9.6.1 | Composite + Plugin Portal (`tools.forma.*`) |
+| `application/` | Sample Android product (gold standard) | 9.6.1 | Consumer only |
+| `jvm-application/` | Sample pure-JVM product (`tools.forma.jvm`) | 9.6.1 | Consumer only |
+| `includer/` | Settings plugin: auto-`include` subprojects | 9.6.1 | `tools.forma.includer` |
+| `depgen/` | Transitive-deps generation plugin | 9.6.1 | `tools.forma.depgen` (standalone) |
 | `build-settings/` | Shared settings conventions (repos) | — | `includeBuild` / convention plugins |
 | `build-dependencies/` | Typed external dep catalogs for sample | — | `includeBuild` as `tools.forma.demo:dependencies` |
 | `docs/`, `scripts/` | Worker/env docs (not Gradle) | — | — |
@@ -55,7 +55,7 @@ that compose via `includeBuild`:
 - `includeBuild("../build-settings")`, `../plugins`, `../includer`
 - Settings plugins: `convention-dependencies`, `tools.forma.includer`, `tools.forma.android`, Gradle Enterprise
 - `includeBuild("../build-dependencies")` for demo catalog
-- Heavy `buildscript` resolution forces (AGP **8.13.2**, bundletool, asm, guava, …)
+- Heavy `buildscript` resolution forces (AGP **9.3.0**, bundletool, asm, guava, …)
 
 **Plugins build** (`plugins/settings.gradle.kts`):
 
@@ -110,7 +110,7 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
 | `:android` | `tools.forma.android` | `:core` + all of the above + **AGP** + Kotlin GP | Target DSL; `AndroidTargetTypes` + `AndroidRestrictionKit` (F-021); content helpers call core `ContentRule` (F-022) |
 | `:jvm` | `tools.forma.jvm` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin GP (**no AGP**) | Pure JVM DSL (`api`/`impl`/`library`/`util`/`testUtil` in package `tools.forma.jvm`); `JvmTargetTypes` + `JvmTargetRegistry` (F-030) |
 
-`:android` compiles against **AGP 8.13.2** (aligned with sample
+`:android` compiles against **AGP 9.3.0** (aligned with sample
 `androidProjectConfiguration(agpVersion = …)` — F-018 / #182). Keep
 `plugins/android` AGP compile dep and consumer `agpVersion` in lockstep.
 AGP 9 is **F-019** only with explicit OK.
@@ -265,7 +265,7 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
         extraPlugins = listOf(
             // classpath only — see PROJECT-CONFIGURATION.md + TARGET-PLUGINS.md
             libs.plugins.toolsFormaDemoDependencies,
@@ -293,7 +293,7 @@ Concurrency group `ci-${{ github.workflow }}-${{ github.ref }}` cancels in-progr
 
 CI pins (evolved F-004 → F-018):
 
-1. **All jobs** pin Temurin **21** via `actions/setup-java@v4` (was 17; requires Gradle ≥8.5 — wrappers are **8.14.5**).
+1. **All jobs** pin Temurin **21** via `actions/setup-java@v4` (was 17; requires Gradle ≥8.5 — wrappers are **9.6.1**).
 2. **Application** installs Android SDK packages matching sample `compileSdk` **35** / target **35**.
 3. README badge → `formatools/forma` + `actions/workflows/main.yml/badge.svg`.
 4. Gradle setup via `gradle/actions/setup-gradle@v4` (successor of `gradle-build-action`).
@@ -310,9 +310,9 @@ keys) or full Portal publish via secrets; deeper Gradle remote cache.
 |-----------|---------------------|
 | JDK (daemon / CI) | **21** (CI Temurin 21; host OpenJDK 21 via Homebrew `openjdk@21`) |
 | App bytecode / `jvmTarget` | unchanged (sample default `JavaVersion.VERSION_1_8`) — not raised with daemon JDK |
-| Gradle | **8.14.5** (all wrappers; F-018 #180→#182) |
-| AGP | **8.13.2** sample runtime + plugins compile (F-018 / #182) |
-| Kotlin | embeddedKotlin from Gradle 8.14.5 (**2.0.21**); KSP **2.0.21-1.0.28**; Compose compiler default **2.0.21** |
+| Gradle | **9.6.1** (all wrappers; F-019) |
+| AGP | **9.3.0** sample runtime + plugins compile (F-019) |
+| Kotlin | embeddedKotlin from Gradle 9.6.1 (**2.3.21**); KSP **2.3.10**; Compose compiler default **2.3.21** |
 | Android SDK | sample min **23** / target **35** / compile **35**; host platforms 35+34+33 + build-tools 33/34 |
 | Forma version | 0.1.3 |
 
@@ -365,7 +365,7 @@ Suggested extraction order (tickets F-020…F-024):
 | ~~README dependency matrix ≠ live validators~~ → [`docs/DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md) | F-010 done |
 | ~~`EmptyValidator` on app/binary/(historical androidLibrary)~~ (composition-root + library allowlists) | F-011 done; androidLibrary removed F-063 |
 | ~~AGP 7.4.2 compile vs 8.1.2 runtime~~ (aligned 8.1.2) | F-003 done |
-| ~~F-018 8.x ladder~~ (JDK 21, Gradle 8.14.5, AGP 8.13.2, deps) | F-018 done (#179–#182); AGP 9 = F-019 |
+| ~~F-018 8.x ladder~~ (JDK 21, Gradle 9.6.1, AGP 9.3.0, deps) | F-018 done (#179–#182); F-019 in progress (9.x) |
 | ~~CI missing SDK + Java on some jobs~~ (GHA green on PR #153) | F-004 done |
 | ~~Compose flag in settings, limited target support~~ → per-target flags + `composeWidget` | F-013 done |
 | ~~Missing Android getting-started tutorial~~ → [`docs/GETTING-STARTED.md`](GETTING-STARTED.md) | F-015 done |

--- a/docs/COMPOSE.md
+++ b/docs/COMPOSE.md
@@ -14,9 +14,9 @@ androidProjectConfiguration(
     targetSdk = 33,
     // compileSdk 34 when using modern Compose transitive AARs
     compileSdk = 34,
-    agpVersion = "8.13.2",
+    agpVersion = "9.3.0",
     compose = false, // default for per-target flags
-    composeCompilerVersion = "2.0.21", // must match Kotlin (2.0.21 → 2.0.21)
+    composeCompilerVersion = "2.3.21", // must match Kotlin (2.3.21 → 2.3.21)
 )
 ```
 
@@ -97,8 +97,8 @@ Full matrix: [`DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md).
 
 ## Compiler / Kotlin pairing
 
-Default `composeCompilerVersion = "2.0.21"` matches Kotlin **2.0.21** (Gradle
-**8.14.5** embedded Kotlin used by the sample). On Kotlin **2.0+**, Forma also
+Default `composeCompilerVersion = "2.3.21"` matches Kotlin **2.3.21** (Gradle
+**9.6.1** embedded Kotlin used by the sample). On Kotlin **2.0+**, Forma also
 applies the **Compose Compiler Gradle plugin** when `compose = true` (the
 `composeCompilerVersion` value remains the paired compiler coordinate for AGP
 `composeOptions` / tooling). If you bump Kotlin, update

--- a/docs/ENV.md
+++ b/docs/ENV.md
@@ -22,7 +22,7 @@ printf 'sdk.dir=%s\n' "$ANDROID_HOME" > application/local.properties
 
 # Verify
 java -version   # expect 21.x
-cd plugins && ./gradlew --version   # Gradle 8.14.5 + JVM 21
+cd plugins && ./gradlew --version   # Gradle 9.6.1 + JVM 21
 cd ../plugins && ./gradlew build
 cd ../application && ./gradlew build
 cd ../includer && ./gradlew build
@@ -76,16 +76,16 @@ sudo ln -sfn /usr/local/opt/openjdk@21/libexec/openjdk.jdk \
   /Library/Java/JavaVirtualMachines/openjdk-21.jdk
 ```
 
-## Verified on 2026-07-19 (F-018 complete — 8.x terminal)
+## Verified on 2026-07-20 (F-019 Phase 1 — Gradle 9 + Kotlin 2.3 + AGP 9)
 
 - `java` / `javac` **21.x** (Homebrew OpenJDK 21) via `scripts/env-mac.sh`
-- Gradle wrappers: **8.14.5** (all roots; unified via #180 then #182)
-- AGP **8.13.2** lockstep (`plugins/android` compile + sample `agpVersion`)
-- Kotlin **2.0.21** (Gradle embedded); KSP **2.0.21-1.0.28**
-- Compose compiler default **2.0.21** (+ Kotlin Compose Compiler plugin when `compose=true`)
+- Gradle wrappers: **9.6.1** (all roots; F-019)
+- AGP **9.3.0** lockstep (`plugins/android` compile + sample `agpVersion`)
+- Kotlin **2.3.21** (Gradle embedded); KSP **2.3.10**
+- Compose compiler default **2.3.21** (+ Kotlin Compose Compiler plugin when `compose=true`)
 - Sample SDK: min **23** / target **35** / compile **35** (install platform 35 for full sample builds; 34/33 still useful)
 - CI: Temurin **21** all jobs (`.github/workflows/main.yml`)
-- AGP 9 / Gradle 9 / absolute-latest AndroidX = **F-019** only with explicit OK
+- F-019 in progress: Gradle 9.6.1 + Kotlin 2.3.21 + AGP 9.3.0
 
 See `docs/PROGRESS.md` for the latest host build tails.
 

--- a/docs/GETTING-STARTED.md
+++ b/docs/GETTING-STARTED.md
@@ -46,8 +46,8 @@ structure and boundaries, not business logic.
 | JDK | **21** build/daemon (F-018); app language level unchanged |
 | Android SDK | Platform **35** (`compileSdk` / modern Compose + AndroidX AARs); **34**/**33** still useful |
 | Build tools | 33.0.2 / 34.0.0 as used by the sample |
-| Gradle | Use the wrapper in the project (`./gradlew`); **8.14.5** all roots |
-| AGP | **8.13.2** (keep consumer `agpVersion` aligned with plugin compile AGP) |
+| Gradle | Use the wrapper in the project (`./gradlew`); **9.6.1** all roots |
+| AGP | **9.3.0** (keep consumer `agpVersion` aligned with plugin compile AGP) |
 
 Worker / macOS install steps: [ENV.md](ENV.md) (`source scripts/env-mac.sh`).
 
@@ -165,9 +165,9 @@ buildscript {
         minSdk = 21,
         targetSdk = 33,
         compileSdk = 34,          // 34 if you use modern Compose transitive AARs
-        agpVersion = "8.13.2",     // keep aligned with plugin compile AGP
+        agpVersion = "9.3.0",     // keep aligned with plugin compile AGP
         // compose = false,       // project default for per-target compose flags
-        // composeCompilerVersion = "2.0.21", // match your Kotlin (2.0.21 → 2.0.21)
+        // composeCompilerVersion = "2.3.21", // match your Kotlin (2.3.21 → 2.3.21)
         // Classpath only — does NOT apply plugins to modules. See TARGET-PLUGINS.md.
         extraPlugins = listOf(
             // e.g. libs.plugins.navigationSafeArgs (jar on buildscript classpath)
@@ -440,8 +440,8 @@ Details: [COMPOSE.md](COMPOSE.md). Sample:
 | Project not included | Missing `build.gradle.kts`, or nested `settings.gradle.kts` blocked Includer |
 | Illegal project dependency | Matrix violation — see [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md) |
 | Empty / wrong package | `packageName` ≠ directory under `src/main/java` |
-| Compose compiler mismatch | Align `composeCompilerVersion` with Kotlin (sample: 2.0.21 ↔ 2.0.21) |
-| AGP resolution conflicts | Align consumer `agpVersion` with plugin AGP line (**8.13.2** today) |
+| Compose compiler mismatch | Align `composeCompilerVersion` with Kotlin (sample: 2.3.21 ↔ 2.3.21) |
+| AGP resolution conflicts | Align consumer `agpVersion` with plugin AGP line (**9.3.0** today) |
 
 ---
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,35 @@
 
 Newest entries first.
 
+## 2026-07-20 — F-019: Gradle 9.6.1 + Kotlin 2.3.21 + AGP 9.3.0
+
+- **Ticket:** F-019 → `done` (Phase 1)
+- **Branch:** `forma/F-019-gradle9-kotlin` (from origin/v2)
+- **User OK:** explicit “Schedule Kotlin and Gradle 9 upgrade” (topic 136)
+- **Pins:**
+  - All **24** wrappers → Gradle **9.6.1** (embedded Kotlin **2.3.21**)
+  - AGP lockstep **9.3.0** (`plugins/android` + sample `agpVersion` + forces)
+  - aapt2-proto **9.3.0-15703166**; KSP **2.3.10**; Compose compiler default **2.3.21**
+  - Dagger **2.60.1** (Kotlin metadata 2.3 support)
+- **Forma / Gradle 9 API:**
+  - `ProjectDependency.dependencyProject` removed → resolve via `path` + `Project.target(ProjectDependency)`
+  - `String.capitalized()` → `replaceFirstChar` titlecase
+  - `kotlinOptions.jvmTarget` → `compilerOptions.jvmTarget` + `JvmTarget.fromTarget`
+  - Drop `-Xcontext-receivers` (superseded in Kotlin 2.3)
+  - AGP public DSL: `com.android.build.api.dsl.LibraryExtension` / `CommonExtension` (no type args); libraries no longer set `targetSdk`
+  - Sample: explicit `viewModels<CharacterFavoriteViewModel>()` (Kotlin 2.3 reified intersection error)
+- **AGP 9 consumer flags (Phase 1):** `android.builtInKotlin=false` + `android.newDsl=false` while sample still uses **kapt**/Dagger. Phase 2 = built-in Kotlin + kapt→KSP.
+- **Other:** includer TestKit JVM **17** + foojay-resolver **1.0.0**
+- **Verify (real host, `source scripts/env-mac.sh`):**
+  - `plugins/ ./gradlew build` → **BUILD SUCCESSFUL**
+  - `application/ ./gradlew build` → **BUILD SUCCESSFUL** (2363 tasks)
+  - `jvm-application/ ./gradlew build` → **BUILD SUCCESSFUL**
+  - `includer/ ./gradlew build` → **BUILD SUCCESSFUL**
+  - `depgen/ ./gradlew build` → **BUILD SUCCESSFUL**
+  - `plugins/ ./gradlew --version` → Gradle **9.6.1** / Kotlin **2.3.21** / JVM 21
+- **Blockers:** none for Phase 1
+- **Next:** F-083 external-deps house style; F-019 Phase 2 (built-in Kotlin + KSP) when prioritized
+
 ## 2026-07-20 — F-082: One global configuration path
 
 - **Ticket:** F-082 → `done`

--- a/docs/PROJECT-CONFIGURATION.md
+++ b/docs/PROJECT-CONFIGURATION.md
@@ -12,9 +12,9 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
         // compose = false,
-        // composeCompilerVersion = "2.0.21",
+        // composeCompilerVersion = "2.3.21",
         extraPlugins = listOf(
             // jars / Provider<PluginDependency> for the *buildscript classpath only*
             libs.plugins.navigationSafeArgs,

--- a/docs/SAMPLE-APP.md
+++ b/docs/SAMPLE-APP.md
@@ -107,7 +107,7 @@ printf 'sdk.dir=%s\n' "$ANDROID_HOME" > application/local.properties
 cd application && ./gradlew build
 ```
 
-Toolchain: AGP **8.13.2**, compileSdk **35**, targetSdk **35**, Gradle **8.14.5**,
+Toolchain: AGP **9.3.0**, compileSdk **35**, targetSdk **35**, Gradle **9.6.1**,
 build JDK **21** (app language level unchanged). See [ENV.md](ENV.md),
 [COMPOSE.md](COMPOSE.md), [ARCHITECTURE.md](ARCHITECTURE.md).
 

--- a/examples/agent-skills/forma-compose.md
+++ b/examples/agent-skills/forma-compose.md
@@ -9,7 +9,7 @@ Doc: `docs/COMPOSE.md`. Example: `examples/android/06-compose`.
 
 ```kotlin
 // root
-androidProjectConfiguration(..., compose = true, composeCompilerVersion = "2.0.21")
+androidProjectConfiguration(..., compose = true, composeCompilerVersion = "2.3.21")
 
 impl(..., compose = true, dependencies = transitiveDeps("androidx.compose.ui:ui:…", /* … */))
 composeWidget(packageName = "…", dependencies = transitiveDeps(/* compose libs */))
@@ -18,5 +18,5 @@ androidBinary(..., compose = true, ...)
 
 - Forma enables `buildFeatures.compose` + compiler extension version
 - **You** still add Compose Maven artifacts
-- Align compiler version with Kotlin (sample: 2.0.21 ↔ 2.0.21)
+- Align compiler version with Kotlin (sample: 2.3.21 ↔ 2.3.21)
 - **`deps("gav")` is non-transitive** — use `transitiveDeps(...)` for Compose (same as `androidx.compose` in `build-dependencies/`)

--- a/examples/android/01-hello-apk/build.gradle.kts
+++ b/examples/android/01-hello-apk/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2"
+        agpVersion = "9.3.0"
     )
 }

--- a/examples/android/01-hello-apk/gradle.properties
+++ b/examples/android/01-hello-apk/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/01-hello-apk/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/01-hello-apk/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/02-feature-api-impl/build.gradle.kts
+++ b/examples/android/02-feature-api-impl/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
     )
 }

--- a/examples/android/02-feature-api-impl/gradle.properties
+++ b/examples/android/02-feature-api-impl/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/02-feature-api-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/02-feature-api-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/03-res-viewbinding/build.gradle.kts
+++ b/examples/android/03-res-viewbinding/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
     )
 }

--- a/examples/android/03-res-viewbinding/gradle.properties
+++ b/examples/android/03-res-viewbinding/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/03-res-viewbinding/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/03-res-viewbinding/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/04-shared-libs/build.gradle.kts
+++ b/examples/android/04-shared-libs/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
     )
 }

--- a/examples/android/04-shared-libs/gradle.properties
+++ b/examples/android/04-shared-libs/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/04-shared-libs/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/04-shared-libs/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/05-widget-ui/build.gradle.kts
+++ b/examples/android/05-widget-ui/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
     )
 }

--- a/examples/android/05-widget-ui/gradle.properties
+++ b/examples/android/05-widget-ui/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/05-widget-ui/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/05-widget-ui/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/06-compose/build.gradle.kts
+++ b/examples/android/06-compose/build.gradle.kts
@@ -4,8 +4,8 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
         compose = true,
-        composeCompilerVersion = "2.0.21",
+        composeCompilerVersion = "2.3.21",
     )
 }

--- a/examples/android/06-compose/gradle.properties
+++ b/examples/android/06-compose/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/06-compose/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/06-compose/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/07-multi-feature/build.gradle.kts
+++ b/examples/android/07-multi-feature/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
     )
 }

--- a/examples/android/07-multi-feature/gradle.properties
+++ b/examples/android/07-multi-feature/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/07-multi-feature/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/07-multi-feature/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/08-deps-catalog/build.gradle.kts
+++ b/examples/android/08-deps-catalog/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
     )
 }

--- a/examples/android/08-deps-catalog/gradle.properties
+++ b/examples/android/08-deps-catalog/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/08-deps-catalog/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/08-deps-catalog/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/09-test-utils/build.gradle.kts
+++ b/examples/android/09-test-utils/build.gradle.kts
@@ -4,6 +4,6 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
     )
 }

--- a/examples/android/09-test-utils/gradle.properties
+++ b/examples/android/09-test-utils/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/09-test-utils/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/09-test-utils/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/android/10-target-plugins/build.gradle.kts
+++ b/examples/android/10-target-plugins/build.gradle.kts
@@ -4,7 +4,7 @@ buildscript {
         minSdk = 23,
         targetSdk = 35,
         compileSdk = 35,
-        agpVersion = "8.13.2",
+        agpVersion = "9.3.0",
         // extraPlugins = classpath only (buildscript). Type-owned plugins auto-apply per target.
         extraPlugins = listOf(
             libs.plugins.toolsFormaExamplesDefs,

--- a/examples/android/10-target-plugins/gradle.properties
+++ b/examples/android/10-target-plugins/gradle.properties
@@ -7,4 +7,8 @@ android.useAndroidX=true
 android.enableJetifier=false
 kotlin.code.style=official
 android.nonTransitiveRClass=true
-android.defaults.buildfeatures.buildconfig=false
+
+
+
+android.builtInKotlin=false
+android.newDsl=false

--- a/examples/android/10-target-plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/android/10-target-plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/01-hello-binary/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/01-hello-binary/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/02-api-impl/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/02-api-impl/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/03-library-util/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/03-library-util/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/04-multi-feature/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/04-multi-feature/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/examples/jvm/05-test-util/gradle/wrapper/gradle-wrapper.properties
+++ b/examples/jvm/05-test-util/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/includer/gradle/wrapper/gradle-wrapper.properties
+++ b/includer/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/includer/plugin/build.gradle.kts
+++ b/includer/plugin/build.gradle.kts
@@ -12,7 +12,8 @@ repositories {
     mavenCentral()
 }
 
-val javaLanguageVersion = JavaLanguageVersion.of(11)
+// Gradle 9 requires JVM 17+ for the daemon (TestKit functional tests).
+val javaLanguageVersion = JavaLanguageVersion.of(17)
 kotlin {
     jvmToolchain {
         languageVersion.set(javaLanguageVersion)

--- a/includer/settings.gradle.kts
+++ b/includer/settings.gradle.kts
@@ -1,7 +1,7 @@
 rootProject.name = "includer"
 
 plugins {
-    id("org.gradle.toolchains.foojay-resolver-convention") version("0.4.0")
+    id("org.gradle.toolchains.foojay-resolver-convention") version("1.0.0")
 }
 
 include("plugin")

--- a/jvm-application/gradle/wrapper/gradle-wrapper.properties
+++ b/jvm-application/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugins/android/build.gradle.kts
+++ b/plugins/android/build.gradle.kts
@@ -11,14 +11,14 @@ formaPublishedPlugin(name = "android")
 
 tasks.named("compileKotlin", KotlinCompilationTask::class.java) {
     compilerOptions {
-        freeCompilerArgs.add("-Xcontext-receivers")
+        // context receivers removed in Kotlin 2.3 (superseded by context parameters)
     }
 }
 
 dependencies {
     // Compile against the same AGP line the sample forces at runtime (see application/settings.gradle.kts).
     // Keep this in lockstep with androidProjectConfiguration(agpVersion=…) consumers (F-003).
-    implementation("com.android.tools.build:gradle:8.13.2")
+    implementation("com.android.tools.build:gradle:9.3.0")
     implementation(embeddedKotlin("gradle-plugin"))
     implementation(project(":target"))
     implementation(project(":validation"))

--- a/plugins/android/src/main/java/androidProjectConfiguration.kt
+++ b/plugins/android/src/main/java/androidProjectConfiguration.kt
@@ -26,7 +26,7 @@ import tools.forma.config.SettingsStore
  *         minSdk = 23,
  *         targetSdk = 35,
  *         compileSdk = 35,
- *         agpVersion = "8.13.2",
+ *         agpVersion = "9.3.0",
  *         // ...
  *     )
  * }
@@ -119,8 +119,8 @@ fun ScriptHandlerScope.androidProjectConfiguration(
     registerAndroidDefaults()
 }
 
-/** Compose Compiler matching Kotlin 2.0.21 (Gradle 8.14.5 embedded Kotlin). */
-const val DEFAULT_COMPOSE_COMPILER_VERSION = "2.0.21"
+/** Compose Compiler matching Kotlin 2.3.21 (Gradle 9.6.1 embedded Kotlin). */
+const val DEFAULT_COMPOSE_COMPILER_VERSION = "2.3.21"
 
 val buildScriptConfiguration: ScriptHandlerScope.(List<Any>) -> Unit = { classpathDeps ->
     // TODO pass repositories configuration

--- a/plugins/android/src/main/java/publicApi.kt
+++ b/plugins/android/src/main/java/publicApi.kt
@@ -1,7 +1,8 @@
-import com.android.build.gradle.BaseExtension
+import com.android.build.api.dsl.CommonExtension
 import org.gradle.api.Project
 import org.gradle.kotlin.dsl.the
 
-fun Project.getDefaultProguardFile(name: String) = the<BaseExtension>().getDefaultProguardFile(name)
+fun Project.getDefaultProguardFile(name: String) =
+    the<CommonExtension>().getDefaultProguardFile(name)
 
 val androidJunitRunner = "androidx.test.runner.AndroidJUnitRunner"

--- a/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/AndroidLibrary.kt
@@ -1,8 +1,7 @@
 package tools.forma.android.feature
 
 import androidJunitRunner
-import com.android.build.gradle.LibraryExtension
-import org.gradle.kotlin.dsl.get
+import com.android.build.api.dsl.LibraryExtension
 import tools.forma.android.target.LibraryTargetTemplate
 import tools.forma.android.utils.BuildConfiguration
 import tools.forma.android.utils.applyFrom
@@ -44,9 +43,9 @@ fun androidLibraryFeatureDefinition(
                 feature.manifestPlaceholders
             )
 
-            sourceSets["main"].java.srcDirs("src/main/kotlin")
-            sourceSets["test"].java.srcDirs("src/test/kotlin")
-            sourceSets["androidTest"].java.srcDirs("src/androidTest/kotlin")
+            sourceSets.getByName("main").java.srcDir("src/main/kotlin")
+            sourceSets.getByName("test").java.srcDir("src/test/kotlin")
+            sourceSets.getByName("androidTest").java.srcDir("src/androidTest/kotlin")
 
             buildTypes.applyFrom(feature.buildConfiguration)
             compileOptions.applyFrom(formaConfiguration)
@@ -56,7 +55,7 @@ fun androidLibraryFeatureDefinition(
                 enableCompose(project, formaConfiguration.composeCompilerVersion)
             }
         }
-        // AGP 8.13+ library `verify*Resources` is overly strict with Navigation safe-args
+        // AGP library `verify*Resources` is overly strict with Navigation safe-args
         // graphs in pure `androidRes` modules (debug APK still packages graphs correctly).
         project.tasks.matching { it.name.startsWith("verify") && it.name.endsWith("Resources") }
             .configureEach { enabled = false }

--- a/plugins/android/src/main/java/tools/forma/android/feature/AndroidNative.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/AndroidNative.kt
@@ -2,7 +2,7 @@
 package tools.forma.android.feature
 
 import androidJunitRunner
-import com.android.build.gradle.LibraryExtension
+import com.android.build.api.dsl.LibraryExtension
 import tools.forma.android.config.*
 import tools.forma.android.target.NativeTarget
 import tools.forma.android.utils.applyFrom

--- a/plugins/android/src/main/java/tools/forma/android/feature/ComposeSupport.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/ComposeSupport.kt
@@ -11,12 +11,12 @@ internal fun Project.applyKotlinComposeCompilerPlugin() {
 /**
  * Turn on Compose for an AGP module extension and apply the Kotlin Compose Compiler plugin.
  */
-internal fun CommonExtension<*, *, *, *, *, *>.enableCompose(
+internal fun CommonExtension.enableCompose(
     project: Project,
     composeCompilerVersion: String,
 ) {
     project.applyKotlinComposeCompilerPlugin()
     buildFeatures.compose = true
-    // Legacy pin — still accepted by AGP 8.x alongside the Compose Compiler plugin
+    // Legacy pin — still accepted alongside the Compose Compiler plugin
     composeOptions.kotlinCompilerExtensionVersion = composeCompilerVersion
 }

--- a/plugins/android/src/main/java/tools/forma/android/feature/FeatureDefinition.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/FeatureDefinition.kt
@@ -11,8 +11,13 @@ import org.gradle.kotlin.dsl.the
 import tools.forma.deps.core.addDependencyTo
 
 data class FeatureDefinition<Extension : Any, FeatureConfiguration : Any>(
+    /** Gradle plugin id to apply. Blank = no plugin (e.g. AGP 9 built-in Kotlin config-only). */
     val pluginName: String,
-    val pluginExtension: KClass<Extension>,
+    /**
+     * Extension type looked up via `project.the`. Null when [pluginName] is blank / no extension
+     * (then [configuration] receives [Unit] cast to [Extension]).
+     */
+    val pluginExtension: KClass<Extension>? = null,
     val featureConfiguration: FeatureConfiguration,
     val defaultDependencies: NamedDependency = emptyDependency(),
     /**
@@ -23,18 +28,25 @@ data class FeatureDefinition<Extension : Any, FeatureConfiguration : Any>(
     val androidProjectSettings: AndroidProjectSettings? = null,
     val configuration: (Extension, FeatureConfiguration, Project, AndroidProjectSettings) -> Unit
 ) {
-    fun applyConfiguration(project: Project) = configuration(
-        project.the(pluginExtension),
-        featureConfiguration,
-        project,
-        androidProjectSettings ?: Forma.settings
-    )
+    @Suppress("UNCHECKED_CAST")
+    fun applyConfiguration(project: Project) {
+        val settings = androidProjectSettings ?: Forma.settings
+        val extension: Extension =
+            if (pluginExtension != null) {
+                project.the(pluginExtension)
+            } else {
+                Unit as Extension
+            }
+        configuration(extension, featureConfiguration, project, settings)
+    }
 }
 
 fun Project.applyFeatures(
     vararg features: FeatureDefinition<*, *>
 ) = features.forEach { definition ->
-    apply(plugin = definition.pluginName)
+    if (definition.pluginName.isNotBlank()) {
+        apply(plugin = definition.pluginName)
+    }
     definition.applyConfiguration(this)
     val defaults = definition.defaultDependencies.names
     if (defaults.isNotEmpty()) {

--- a/plugins/android/src/main/java/tools/forma/android/feature/Kotlin.kt
+++ b/plugins/android/src/main/java/tools/forma/android/feature/Kotlin.kt
@@ -4,6 +4,7 @@ import deps
 import kapt
 import tools.forma.config.AndroidProjectSettings
 import org.gradle.api.Project
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.dsl.KotlinAndroidProjectExtension
 import org.jetbrains.kotlin.gradle.dsl.KotlinJvmProjectExtension
 import org.jetbrains.kotlin.gradle.plugin.KaptExtension
@@ -13,12 +14,13 @@ import tools.forma.deps.core.ConfigurationType
 import tools.forma.deps.core.Kapt
 
 private fun defaultConfiguration(project: Project, androidProjectSettings: AndroidProjectSettings) {
+    val jvm = androidProjectSettings.javaVersionCompatibility.toString()
     project.tasks.withType(JavaCompile::class.java).configureEach {
-        targetCompatibility = androidProjectSettings.javaVersionCompatibility.toString()
-        sourceCompatibility = androidProjectSettings.javaVersionCompatibility.toString()
+        targetCompatibility = jvm
+        sourceCompatibility = jvm
     }
     project.tasks.withType(KotlinCompile::class.java).configureEach {
-        kotlinOptions.jvmTarget = androidProjectSettings.javaVersionCompatibility.toString()
+        compilerOptions.jvmTarget.set(JvmTarget.fromTarget(jvm))
     }
 }
 
@@ -26,20 +28,24 @@ private val sharedFeatureConfiguration:
     (Any, Any, Project, AndroidProjectSettings) -> Unit =
     { _, _, project, configuration -> defaultConfiguration(project, configuration) }
 
+/**
+ * F-019 Phase 1: keep `kotlin-android` + kapt under
+ * `android.builtInKotlin=false` + `android.newDsl=false`.
+ * Phase 2: built-in Kotlin + migrate kapt→KSP (Dagger) and drop these plugins.
+ */
+private val kotlinAndroidFeatureDefinitionInstance =
+    FeatureDefinition(
+        pluginName = "kotlin-android",
+        pluginExtension = KotlinAndroidProjectExtension::class,
+        featureConfiguration = Unit,
+        configuration = sharedFeatureConfiguration
+    )
+
 /** Cached — same definition for every pure-JVM target (F-017). */
 private val kotlinFeatureDefinitionInstance =
     FeatureDefinition(
         pluginName = "kotlin",
         pluginExtension = KotlinJvmProjectExtension::class,
-        featureConfiguration = Unit,
-        configuration = sharedFeatureConfiguration
-    )
-
-/** Cached — same definition for every Android library / widget target (F-017). */
-private val kotlinAndroidFeatureDefinitionInstance =
-    FeatureDefinition(
-        pluginName = "kotlin-android",
-        pluginExtension = KotlinAndroidProjectExtension::class,
         featureConfiguration = Unit,
         configuration = sharedFeatureConfiguration
     )

--- a/plugins/android/src/main/java/tools/forma/android/utils/android.kt
+++ b/plugins/android/src/main/java/tools/forma/android/utils/android.kt
@@ -28,8 +28,7 @@ internal fun DefaultConfig.applyFrom(
     when (this) {
         is ApplicationDefaultConfig -> targetSdk = androidProjectSettings.targetSdk
         is LibraryDefaultConfig -> {
-            @Suppress("DEPRECATION")
-            targetSdk = androidProjectSettings.targetSdk
+            // AGP 9: libraries no longer expose targetSdk on LibraryDefaultConfig
             if (consumerMinificationFiles.isNotEmpty()) {
                 consumerProguardFiles(*consumerMinificationFiles.toTypedArray())
             }

--- a/plugins/config/src/main/java/tools/forma/config/AndroidProjectSettings.kt
+++ b/plugins/config/src/main/java/tools/forma/config/AndroidProjectSettings.kt
@@ -40,7 +40,7 @@ data class AndroidProjectSettings(
      * Jetpack Compose compiler extension version applied when a target enables
      * Compose (`composeOptions.kotlinCompilerExtensionVersion`). Must match the
      * Kotlin version used by the project (see Compose Compiler compatibility map).
-     * Default `2.0.21` pairs with Kotlin **2.0.21** (Gradle 8.14.5 embedded Kotlin used
+     * Default `2.3.21` pairs with Kotlin **2.3.21** (Gradle 9.6.1 embedded Kotlin used
      * by the sample application). Override when bumping Kotlin.
      */
     val composeCompilerVersion: String,

--- a/plugins/deps/src/main/java/dependencies.kt
+++ b/plugins/deps/src/main/java/dependencies.kt
@@ -3,7 +3,7 @@ import org.gradle.api.Project
 import org.gradle.api.artifacts.Dependency
 import org.gradle.api.artifacts.ExternalModuleDependencyBundle
 import org.gradle.api.artifacts.MinimalExternalModuleDependency
-import org.gradle.api.internal.catalog.DelegatingProjectDependency
+import org.gradle.api.artifacts.ProjectDependency
 import org.gradle.api.provider.Provider
 import tools.forma.config.FormaSettingsStore
 import tools.forma.deps.core.CustomConfiguration
@@ -189,8 +189,9 @@ fun deps(vararg dependencies: NamedDependency): NamedDependency {
     return NamedDependency(out)
 }
 
-fun deps(vararg projects: DelegatingProjectDependency) =
-    projects.map { TargetSpec(target(it)) }.let(::TargetDependency)
+/** Typesafe project accessors / [ProjectDependency] → target deps (Gradle 9: path only, no dependencyProject). */
+fun Project.deps(vararg projects: ProjectDependency): TargetDependency =
+    TargetDependency(projects.map { TargetSpec(target(it)) })
 
 fun deps(vararg dependencies: Provider<*>): NamedDependency {
     if (dependencies.isEmpty()) return NamedDependency()
@@ -240,5 +241,9 @@ val Project.target: FormaTarget
 fun Project.target(name: String): FormaTarget =
     project(":" + name.substring(1).replace(":", "-")).target
 
-fun target(projectDependency: DelegatingProjectDependency): FormaTarget =
-    projectDependency.dependencyProject.target
+/**
+ * Resolve a [ProjectDependency] (including typesafe project accessors) to a [FormaTarget].
+ * Gradle 9 removed [ProjectDependency]→Project (`dependencyProject`); use [ProjectDependency.getPath].
+ */
+fun Project.target(projectDependency: ProjectDependency): FormaTarget =
+    project(projectDependency.path).target

--- a/plugins/deps/src/main/java/tools/forma/deps/catalog/Generators.kt
+++ b/plugins/deps/src/main/java/tools/forma/deps/catalog/Generators.kt
@@ -71,7 +71,11 @@ internal fun generateName(
             .asSequence()
             .filter { it.isNotBlank() && it !in filteredTokens }
             .distinct()
-            .joinToString("") { it.capitalized() }
+            .joinToString("") { token ->
+                token.replaceFirstChar { ch ->
+                    if (ch.isLowerCase()) ch.titlecase(Locale.getDefault()) else ch.toString()
+                }
+            }
             .let { raw -> raw.replaceFirstChar { it.lowercase(Locale.getDefault()) } }
 
     require(name.isNotBlank()) {

--- a/plugins/gradle/wrapper/gradle-wrapper.properties
+++ b/plugins/gradle/wrapper/gradle-wrapper.properties
@@ -1,6 +1,6 @@
 distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-8.14.5-bin.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-9.6.1-bin.zip
 networkTimeout=10000
 validateDistributionUrl=true
 zipStoreBase=GRADLE_USER_HOME

--- a/plugins/jvm/src/main/java/tools/forma/jvm/feature/JvmFeature.kt
+++ b/plugins/jvm/src/main/java/tools/forma/jvm/feature/JvmFeature.kt
@@ -4,6 +4,7 @@ import org.gradle.api.JavaVersion
 import org.gradle.api.Project
 import org.gradle.api.tasks.compile.JavaCompile
 import org.gradle.kotlin.dsl.apply
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
 import org.jetbrains.kotlin.gradle.tasks.KotlinCompile
 
 /**
@@ -32,6 +33,6 @@ fun Project.applyKotlinJvm() {
     }
 
     tasks.withType(KotlinCompile::class.java).configureEach {
-        kotlinOptions.jvmTarget = jvmTarget
+        compilerOptions.jvmTarget.set(JvmTarget.fromTarget(jvmTarget))
     }
 }


### PR DESCRIPTION
## Summary
- **F-019 Phase 1** toolchain jump after explicit OK: Gradle **9.6.1** (Kotlin **2.3.21**), AGP **9.3.0**, KSP **2.3.10**, Compose compiler **2.3.21**, Dagger **2.60.1**
- Forma API fixes for Gradle 9 / AGP 9 (ProjectDependency.path, compilerOptions, public LibraryExtension, etc.)
- Sample keeps `android.builtInKotlin=false` + `android.newDsl=false` while kapt/Dagger remains — **Phase 2** = built-in Kotlin + kapt→KSP + AndroidX ceiling

## Verify (host)
- `plugins/`, `application/`, `jvm-application/`, `includer/`, `depgen/` → BUILD SUCCESSFUL
- `./gradlew --version` → Gradle 9.6.1 / Kotlin 2.3.21 / JVM 21

## Test plan
- [x] plugins build
- [x] application build
- [x] jvm-application / includer / depgen builds
- [ ] CI four jobs green