### PR TITLE
F-105: Kotlin Multiplatform design (tools.forma.kmp)

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,11 +57,12 @@ systems like Buck and Bazel.
 8. [forma-core public API design](docs/forma-core-api.md) — extraction contract for types / restrictions / registry (F-020)
 9. [JVM targets](docs/JVM-TARGETS.md) — pure JVM platform plugin `tools.forma.jvm` (F-030)
 10. [JVM sample application](docs/JVM-SAMPLE.md) — multi-module pure-JVM gold standard (`jvm-application/`, F-031)
-11. [Bazel adapter design](docs/BAZEL-ADAPTER.md) — target types to rules, restriction graph to visibility (F-040 design)
-12. [Bazel adapter spike](bazel-adapter/README.md) — generate/check BUILD from Forma model (F-041; JVM-first)
-13. [Bazel sample (experimental)](bazel-sample/) — minimal `kt_jvm_*` workspace exercising forma-core matrix + `impl` ↛ `impl` (F-042)
-14. [**Progressive examples + agent skills**](docs/PROGRESSIVE-EXAMPLES.md) — feature-by-feature ladders (`examples/`) + coding-agent skills (F-050)
-15. [**Test coverage**](docs/TEST-COVERAGE.md) — JaCoCo on `plugins/`, happy-path LINE ≥60% gate
+11. [**Kotlin Multiplatform design**](docs/KMP-TARGETS.md) — `tools.forma.kmp` types, matrix, no call-site target shopping (F-105; implement F-106…F-110)
+12. [Bazel adapter design](docs/BAZEL-ADAPTER.md) — target types to rules, restriction graph to visibility (F-040 design)
+13. [Bazel adapter spike](bazel-adapter/README.md) — generate/check BUILD from Forma model (F-041; JVM-first)
+14. [Bazel sample (experimental)](bazel-sample/) — minimal `kt_jvm_*` workspace exercising forma-core matrix + `impl` ↛ `impl` (F-042)
+15. [**Progressive examples + agent skills**](docs/PROGRESSIVE-EXAMPLES.md) — feature-by-feature ladders (`examples/`) + coding-agent skills (F-050)
+16. [**Test coverage**](docs/TEST-COVERAGE.md) — JaCoCo on `plugins/`, happy-path LINE ≥60% gate
 
 Configuration made easy:
 

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -146,6 +146,22 @@ worker (ops); `v2`→`master` (explicit git promote only). **F-094** stays `bloc
 | F-103 | todo | Hybrid targets example (flat dir / api+impl co-location) | GH **#44** — teaching example: simplified flat layout (api/impl/stub mental model, easy multi-module nav). May use includer layout + progressive example; align with F-084/F-088 fleet layout. No restore of `androidLibrary`. |
 | F-104 | todo | Hybrid configuration / stub targets for IDE sync | GH **#43** — stub targets + deps API so IDE sync can swap `impl`→`stub` (compileOnly/runtimeOnly pattern) via **one project-global flag**, not per-module hacks. Design+spike; depend on F-101/`target` APIs. Keep matrix truth. |
 
+## P11 — Kotlin Multiplatform (Stepan 2026-07-25)
+
+Third Gradle platform on forma-core (`tools.forma.kmp`). **Design:** [`docs/KMP-TARGETS.md`](docs/KMP-TARGETS.md).
+**User priority (2026-07-25):** implement **F-106** next (before F-100…F-104) unless a hotfix blocks.
+v1 = **jvm + android** shared libraries only; type-owned MPP; **no** per-module target shopping;
+composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
+
+| ID | Status | Title | Notes |
+|----|--------|-------|-------|
+| F-105 | done | Design KMP targets + matrix + plugin shape | `docs/KMP-TARGETS.md` — types `kmp-api`/`kmp-library`/`kmp-util`/`kmp-test-util`; `kmpProjectConfiguration`; rejected free-form `kotlin { targets }`; VISION/ARCHITECTURE/README pointers |
+| F-106 | todo | `:kmp` plugin skeleton + `KmpTargetRegistry` matrix tests | Module `plugins/kmp`, plugin id `tools.forma.kmp`, types + `registerKmpDefaults`, unit tests; no half-working public DSL until F-107 |
+| F-107 | todo | Apply kotlin-multiplatform + `kmpLibrary` DSL | Feature applicator jvm+android; deps via commonMain path; spike Android KMP library plugin id under AGP 9.3; `kmpProjectConfiguration` |
+| F-108 | todo | Android/JVM consumer matrix edges → kmp.* | Extend `AndroidTargetRegistry` + `JvmTargetRegistry`; update `DEPENDENCY-MATRIX.md` from code; avoid `:kmp`→`:android` cycle |
+| F-109 | todo | Progressive example `examples/kmp/01-shared-library` | Shared `kmp-library` + JVM (and optional Android) consumer; green documented Gradle tasks |
+| F-110 | todo | KMP user docs + agent skill + curriculum | `KMP-GETTING-STARTED.md`, `examples/agent-skills/forma-kmp-targets.md`, PROGRESSIVE-EXAMPLES ladder, README |
+
 ## Backlog (lower priority / historical GitHub)
 
 Keep for reference; do not start unless higher tickets done or user prioritizes:

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ that compose via `includeBuild`:
 
 - `pluginManagement { includeBuild("../build-settings") }`
 - `tools.forma.includer` **0.2.0** from Portal (not local includer composite)
-- Includer discovers `:android`, `:config`, `:core`, `:deps`, `:jvm`, `:owners`, `:target`, `:validation` (F-021 `:core`; F-030 `:jvm`)
+- Includer discovers `:android`, `:config`, `:core`, `:deps`, `:jvm`, `:owners`, `:target`, `:validation` (F-021 `:core`; F-030 `:jvm`); **`:kmp` planned F-106** (F-105 design)
 
 ---
 
@@ -91,12 +91,12 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
               │           │            │
               └─────┬─────┴────────────┘
                     │
-        ┌───────────┴───────────┐
-        │                       │
-  ┌─────┴─────┐           ┌─────┴─────┐
-  │  android  │           │    jvm    │  F-030 pure JVM DSL + JvmTargetRegistry
-  │  DSL+AGP  │           │  no AGP   │  (parallel platform consumer of core)
-  └───────────┘           └───────────┘
+        ┌───────────┼───────────────────┐
+        │           │                   │
+  ┌─────┴─────┐ ┌───┴────┐        ┌─────┴─────┐
+  │  android  │ │  jvm   │        │    kmp    │  F-105 design; F-106+ module
+  │  DSL+AGP  │ │ no AGP │        │  MPP DSL  │  (tools.forma.kmp)
+  └───────────┘ └────────┘        └───────────┘
 ```
 
 | Module | Plugin id | Depends on | Responsibility |
@@ -109,6 +109,7 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
 | `:deps` | `tools.forma.deps` | `:core`, `:validation`, `:target`, `:config`, kotlin-dsl | `FormaDependency` model, `applyDependencies`, version-catalog generators |
 | `:android` | `tools.forma.android` | `:core` + all of the above + **AGP** + Kotlin GP | Target DSL; `AndroidTargetTypes` + `AndroidRestrictionKit` (F-021); content helpers call core `ContentRule` (F-022) |
 | `:jvm` | `tools.forma.jvm` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin GP (**no AGP**) | Pure JVM DSL (`api`/`impl`/`library`/`util`/`testUtil` in package `tools.forma.jvm`); `JvmTargetTypes` + `JvmTargetRegistry` (F-030) |
+| `:kmp` | `tools.forma.kmp` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin MPP GP (**no** hard dep on `:android`; AGP coords as needed for androidTarget) | **Planned F-106+** — KMP DSL (`kmpLibrary` / `kmpApi` / …); `KmpTargetTypes` + `KmpTargetRegistry`; design [`KMP-TARGETS.md`](KMP-TARGETS.md) (F-105) |
 
 `:android` compiles against **AGP 9.3.0** (aligned with sample
 `androidProjectConfiguration(agpVersion = …)` — F-018 / #182). Keep

--- a/docs/KMP-TARGETS.md
+++ b/docs/KMP-TARGETS.md
@@ -1,0 +1,421 @@
+# Kotlin Multiplatform (KMP) targets — design (F-105)
+
+**Status:** design accepted (F-105). Implementation: **F-106…F-110** (see `TICKETS.md` § P11).
+
+**North star:** KMP is a **third platform adapter** on forma-core (after Android + pure JVM), not a free-form
+`kotlin { targets { … } }` escape hatch. Call sites stay **Bazel-like**: type + attributes. The
+**target type (rule)** owns `org.jetbrains.kotlin.multiplatform` and the platform set. Platforms are
+chosen **once** for the project (or once on a derived type) — never re-selected per module.
+
+**Related:** [`VISION.md`](VISION.md) · [`forma-core-api.md`](forma-core-api.md) · [`JVM-TARGETS.md`](JVM-TARGETS.md) ·
+[`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) · [`DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md) ·
+[`ARCHITECTURE.md`](ARCHITECTURE.md)
+
+Toolchain baseline at design time: **Gradle 9.6.x / Kotlin 2.3.x / AGP 9.3.x / JVM 11** (see F-019 / F-087).
+
+---
+
+## 1. Goals and non-goals
+
+### Goals
+
+1. Let teams share **common Kotlin** across **JVM + Android** (v1) with the same Forma discipline:
+   role-typed modules, closed project-dep matrix, attributes-only call sites.
+2. Ship a **portable platform plugin** `tools.forma.kmp` that depends on forma-core + deps/validation
+   facades — parallel to `tools.forma.jvm`, not a fork of the restriction engine.
+3. Make Android and pure-JVM composition roots **first-class consumers** of KMP libraries
+   (`android.impl` / `androidApp` / `androidBinary` / `jvm.impl` / `jvm.binary` → `kmp.library`).
+4. Keep **one global way** to enable platforms and apply the multiplatform plugin (type-owned +
+   project-global configuration).
+5. Teach via a **progressive example** + agent skill (F-050 ladder style), without rewriting the gold
+   sample app to KMP on day one.
+
+### Non-goals (v1)
+
+| Out of scope for F-105…F-110 | Why / later |
+|------------------------------|-------------|
+| iOS / watchOS / tvOS / macOS native targets | Host + CI tooling; separate phase once JVM+Android green |
+| JS / Wasm / native linux/mingw | Same |
+| Replacing Android `api`/`impl` with KMP everywhere | Android product stays single-platform first |
+| Hierarchical multi-module “one KMP root owns all features” | Fights flat graph; one Gradle project = one Forma target |
+| Call-site `kotlin { androidTarget(); ios() }` | Plugin shopping; rejected |
+| Restoring `androidLibrary` as “shared” bucket | Flat-structure axiom (F-063) |
+| Full cocoapods / XCFramework publish pipeline | Follow-up after iOS targets |
+| Changing forma-core restriction SPI for source sets | Project edges stay suffix/type based; source-set wiring is platform apply |
+
+---
+
+## 2. Problem
+
+Today Forma has two platform plugins:
+
+| Plugin | Module shape | Kotlin plugin |
+|--------|--------------|---------------|
+| `tools.forma.android` | One role per Gradle project; AGP library/app | AGP 9 built-in Kotlin / `kotlin-jvm` for pure JVM rows |
+| `tools.forma.jvm` | One role per Gradle project | `org.jetbrains.kotlin.jvm` |
+
+There is **no** first-class way to declare a shared multiplatform module. Teams would fall back to
+raw Gradle KMP — the opposite of Forma’s meta-build pitch (structure declaration, type-owned tools,
+closed matrix).
+
+Raw KMP also encourages **fat modules** (many source sets, many targets, optional hierarchical
+projects) and **per-module target shopping**. Forma needs the opposite: small role-typed targets and
+fleet-global platform policy.
+
+---
+
+## 3. Design principle
+
+> **The KMP target type owns the multiplatform plugin and the platform set.**
+> Call sites set package + deps (+ rare platform-specific dep attrs). Platforms are not re-listed
+> on every module.
+
+| Layer | Owns | Analogy |
+|-------|------|---------|
+| **Project configuration** | Which platforms exist for this product (v1: jvm + android) | Workspace toolchain / `.bazelrc` |
+| **Type / rule** | `kotlin-multiplatform` + default source-set graph + matrix row | `rule()` in `.bzl` |
+| **Call site** | `packageName`, `dependencies`, optional `androidDependencies` / `jvmDependencies` | `BUILD` attributes |
+
+### Rejected shapes
+
+```kotlin
+// REJECTED — free-form KMP DSL at every module
+plugins { kotlin("multiplatform"); id("com.android.library") }
+kotlin {
+    androidTarget()
+    jvm()
+    iosArm64() // shopping list
+}
+
+// REJECTED — plugin id / target list as call-site attrs
+kmpLibrary(..., platforms = listOf("ios", "jvm"), plugins = …)
+
+// REJECTED — generic shared android library escape hatch
+androidLibrary(...) // removed F-063; do not revive for “common”
+
+// REJECTED — dual happy path: raw KMP modules next to Forma KMP types without matrix
+```
+
+---
+
+## 4. Platform product shape (v1)
+
+### 4.1 New plugin module
+
+```
+plugins/
+  kmp/                    ← new Gradle subproject
+    tools.forma.kmp       ← Settings plugin id (empty apply, Portal pattern)
+    depends on: :core :deps :validation :target :owners
+                + Kotlin Multiplatform Gradle plugin (embeddedKotlin / kotlin-gradle-plugin)
+                + AGP compile-only or api as needed for androidTarget wiring
+```
+
+**Do not** put KMP apply logic into `:android` or `:jvm` as a permanent home. Cross-links:
+
+- `:android` / `:jvm` registries **allow** edges **to** KMP types (F-108).
+- `:kmp` owns types, registry, DSL, feature applicators.
+
+Optional later: thin re-exports so `import tools.forma.android.kmpLibrary` works — **not** v1;
+consumers use `tools.forma.kmp.*` or a single umbrella later.
+
+### 4.2 Target types (v1)
+
+Mirror the pure-JVM kit roles that make sense for **shared** code. Suffixes are **KMP-prefixed** so
+they never collide with `api` / `impl` / `library` on Android or JVM (critical: name matching is
+suffix-based).
+
+| DSL (`tools.forma.kmp`) | Type id | Name suffix | Role |
+|--------------------------|---------|-------------|------|
+| `kmpLibrary` | `kmp.library` | `kmp-library` | Shared multiplatform library (default workhorse) |
+| `kmpApi` | `kmp.api` | `kmp-api` | Shared public contracts (expect/actual-friendly) |
+| `kmpUtil` | `kmp.util` | `kmp-util` | Shared utilities / extensions |
+| `kmpTestUtil` | `kmp.test-util` | `kmp-test-util` | Shared test helpers (commonTest + platform tests) |
+
+**No `kmpImpl` / `kmpBinary` in v1.**
+
+- Feature **implementation** stays on Android `impl` / JVM `impl` (platform UI, DI graphs, apps).
+- Composition roots stay `androidBinary` / `androidApp` / `jvm.binary`.
+- Putting `impl` on KMP would blur “where composition happens” and invite `impl`→`impl` via common.
+
+**Why not reuse suffix `library`?** Android/JVM already use `library` for pure JVM
+(`jvm.library`). A project named `shared-library` would match the wrong type. Explicit
+`…-kmp-library` keeps validators unambiguous.
+
+### 4.3 Platforms enabled (v1)
+
+| Platform | Kotlin target | Android wiring |
+|----------|---------------|----------------|
+| **JVM** | `jvm()` | n/a |
+| **Android** | `androidTarget()` (or current Kotlin 2.3 / AGP 9 recommended API) | **Android KMP Library** plugin path preferred: `com.android.kotlin.multiplatform.library` when supported by pinned AGP; fallback documented in F-107 if spike forces classic `com.android.library` + KMP |
+
+**Single project-global default** (both on):
+
+```kotlin
+// Conceptual — names finalized in F-106/F-107
+kmpProjectConfiguration(
+    project = rootProject,
+    // Platforms are NOT optional per module in the happy path:
+    platforms = KmpPlatforms(jvm = true, android = true),
+    // Android SDK / JVM target pulled from existing AndroidProjectSettings when android platform on,
+    // or minimal kmp-local mirrors when used from a pure KMP+JVM tree without full Android plugin.
+    jvmTarget = "11",
+)
+```
+
+**One global way:** every built-in KMP type receives the same platform set from
+`kmpProjectConfiguration` (or defaults if configuration is implicit on first DSL use — parity with
+`registerJvmDefaults()`).
+
+**Path B later (not v1):** `deriveTargetType` + `iosSharedLibrary` that adds iOS platforms on a
+**derived type** only — still no per-call-site target list.
+
+### 4.4 Source layout (convention)
+
+Forma fleet layout today assumes `src/main/{java,kotlin}/…` ([`SourceLanguage`](../plugins/core/src/main/java/tools/forma/core/fleet/SourceLanguage.kt)).
+KMP needs multiplatform source sets:
+
+```
+shared-kmp-library/
+  build.gradle.kts          # kmpLibrary(packageName = "com.example.shared", …)
+  src/
+    commonMain/kotlin/com/example/shared/…
+    commonTest/kotlin/…
+    androidMain/kotlin/…    # optional actuals
+    jvmMain/kotlin/…        # optional actuals
+```
+
+**packageName** still drives fleet check/generate for the **commonMain** tree (and documents the
+root package). F-107/F-109 extend fleet helpers or add `KmpLayout` so `formaLayoutCheck` understands
+`commonMain` (do not force `src/main/kotlin` on KMP modules).
+
+Content rules (v1):
+
+- `kmp.*` modules: **no Android `res/`** under common (resources stay Android `androidRes` / platform UI).
+- Platform-specific Android resources inside a KMP module are **discouraged** in v1 (prefer
+  `androidRes` + consume KMP for code). If AGP KMP library requires a minimal manifest, keep it
+  empty/skeleton owned by the feature applicator — not a call-site concern.
+
+---
+
+## 5. Call-site API (attributes only)
+
+```kotlin
+// shared-kmp-library/build.gradle.kts
+import tools.forma.kmp.kmpLibrary
+import tools.forma.deps.core.deps
+
+kmpLibrary(
+    packageName = "com.example.shared",
+    dependencies = deps(
+        // → commonMain; project deps must be other kmp.* (matrix) or external KMP-friendly GAVs
+        target(project(":core-kmp-api")),
+        libs.some.multiplatform.lib,
+    ),
+    // Optional platform-only deps (attrs, not plugin shopping) — implement if spike needs them:
+    // androidDependencies = deps(…),  // androidMain
+    // jvmDependencies = deps(…),      // jvmMain
+    testDependencies = deps(/* commonTest */),
+)
+```
+
+Same shape for `kmpApi` / `kmpUtil` / `kmpTestUtil` (stricter matrices).
+
+**Unit return** — no builder chains (F-081).
+
+**Target plugins:** KMP types participate in Path A/B (`registerTargetPlugin` /
+`deriveTargetType`) once F-106 registry exists — e.g. a future `serializationKmpLibrary` type owns
+`kotlinx-serialization` plugin. v1 ships registry hooks; no serialization example required.
+
+---
+
+## 6. Dependency matrix
+
+### 6.1 KMP → KMP (project edges)
+
+| Consumer ↓ \ Dep → | kmp-api | kmp-library | kmp-util | kmp-test-util |
+|--------------------|---------|-------------|----------|---------------|
+| **kmp-api** | Y | — | — | — |
+| **kmp-library** | Y | Y* | Y | Y (test) |
+| **kmp-util** | — | — | Y | — |
+| **kmp-test-util** | Y | Y | Y | Y |
+
+\* `kmp-library` → `kmp-library` allowed for layered shared stacks (unlike `impl`↛`impl`). Keep
+shallow; composition of **features** still happens at Android/JVM roots.
+
+**Rules of thumb**
+
+- **No KMP → Android `impl` / `uiLibrary` / `res` / `widget`.** Shared code must not pull UI/graph
+  leaves.
+- **No KMP → pure `jvm.impl`.** Same directionality.
+- KMP **may** depend on **external** multiplatform libraries (catalog / GAV) — not suffix-validated.
+- Whether KMP may depend on pure `jvm.library` / `jvm.util`: **v1 = no** (those modules are
+  Kotlin-JVM plugin artifacts; consuming them from `commonMain` is incorrect). Shared code that is
+  truly common should be `kmp-*`. JVM-only helpers stay on the JVM side and depend **on** KMP if
+  needed.
+
+### 6.2 Android / JVM → KMP (consumer edges)
+
+Extend existing registries (F-108):
+
+| Consumer | May depend on KMP |
+|----------|-------------------|
+| `android.api` | `kmp.api` (contracts only; optional `kmp.library` **no** — keep api thin) |
+| `android.impl` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `android.android-util` | `kmp.library`, `kmp.util` |
+| `android.app` / `android.binary` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `jvm.api` | `kmp.api` |
+| `jvm.impl` / `jvm.binary` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `jvm.library` / `jvm.util` | `kmp.library`, `kmp.util` (optional; prefer depending upward only if needed) |
+
+Update [`DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md) **when code lands** (code truth rule).
+
+### 6.3 How Gradle edges resolve
+
+Project dependency from Android `impl` → `shared-kmp-library` must resolve to the **Android**
+variant/outgoing configuration of the KMP project (KMP plugin metadata). Feature applicator (F-107)
+must enable the Android target + publishing/consumable configuration that AGP/Kotlin expect so
+`implementation(project(":shared-kmp-library"))` works without manual `attributes` at call sites.
+
+`applyDependencies` today maps `Implementation` → `implementation` configuration names. KMP common
+deps need `commonMainImplementation` (or the Kotlin dependency handler API). F-107 either:
+
+1. Uses `CustomConfiguration("commonMainImplementation")` / platform customs for KMP DSL only, or
+2. Adds a small `applyKmpDependencies` that uses `kotlin.sourceSets.commonMain.dependencies { … }`
+   while still running the **same** project-dep validators.
+
+Prefer (2) for correctness with the KMP plugin; keep validation on project deps identical to
+Android/JVM.
+
+---
+
+## 7. Configuration surface
+
+### 7.1 `kmpProjectConfiguration` (new)
+
+Single entrypoint (F-082 spirit), `ScriptHandlerScope` or root `Project` — match whatever pattern
+`:jvm` grows into; Android keeps `androidProjectConfiguration` for AGP/SDK.
+
+Responsibilities:
+
+- Register `KmpTargetRegistry` defaults
+- Store `KmpPlatforms` + `jvmTarget` in a small `KmpProjectSettings` / store
+- Ensure Kotlin MPP (+ Android KMP library) plugins are on the **buildscript/classpath** the same
+  way Android puts AGP on classpath (`extraPlugins` / version alignment with
+  `Forma.settings.kotlinVersion` when Android plugin also applied)
+
+**Classpath rule:** consumers still do not apply plugins in modules. Root puts Kotlin MPP on
+classpath once (document exact coordinates in F-107 + `PLUGIN-PUBLISH` / getting started).
+
+### 7.2 Interaction with Android project configuration
+
+When both Android and KMP plugins are used (expected for mobile monorepos):
+
+| Concern | Source of truth |
+|---------|-----------------|
+| `minSdk` / `compileSdk` / AGP version | `androidProjectConfiguration` |
+| Kotlin version | Android settings today; KMP must **not** introduce a second pin |
+| JVM target | Align with `javaVersionCompatibility` (11) |
+| KMP platforms | `kmpProjectConfiguration` only |
+
+Pure KMP+JVM tree without Android: allow KMP-only config with jvm platform; android platform
+requires Android settings present or fails fast with a clear error.
+
+---
+
+## 8. Implementation slices (ticket map)
+
+| ID | Deliverable | Verify |
+|----|-------------|--------|
+| **F-105** | This design doc + board + VISION/ARCHITECTURE pointers | Review / merge |
+| **F-106** | `:kmp` module skeleton, `KmpTargetTypes`, `KmpTargetRegistry` + unit matrix tests, empty Settings plugin, publish metadata | `plugins/` `:kmp:test` + root plugins build |
+| **F-107** | Feature applicator: apply KMP (+ Android KMP lib), jvm+android targets, source sets, `kmpLibrary` DSL + deps apply path | Unit tests + compile; minimal smoke module if feasible |
+| **F-108** | Extend Android + JVM restriction matrices to allow KMP deps; docs matrix | Registry unit tests; sample edge compile |
+| **F-109** | Progressive example `examples/kmp/01-shared-library` (shared kmp-library + jvm binary and/or tiny android binary consumer) | Documented `./gradlew` tasks green on host |
+| **F-110** | User docs (`KMP-GETTING-STARTED` or section), agent skill, PROGRESSIVE-EXAMPLES ladder, README links | Doc-only + example already green |
+
+Do **not** merge F-107 without a written spike note in PROGRESS if the Android KMP library plugin
+API differs from this doc — update §4.3 in the same PR.
+
+---
+
+## 9. Consumer sketch (end state)
+
+```kotlin
+// settings.gradle.kts
+plugins {
+    id("tools.forma.android") version "0.1.x"
+    id("tools.forma.kmp") version "0.1.x"
+    id("tools.forma.includer")
+}
+
+// root build.gradle.kts (buildscript)
+androidProjectConfiguration(project = rootProject, /* existing */)
+kmpProjectConfiguration(project = rootProject) // defaults: jvm + android
+
+// shared-kmp-library/build.gradle.kts
+kmpLibrary(
+    packageName = "com.example.shared",
+    dependencies = deps(/* common */),
+)
+
+// feature-hello-impl/build.gradle.kts  (Android)
+impl(
+    packageName = "com.example.hello.impl",
+    dependencies = deps(
+        target(project(":shared-kmp-library")),
+        target(project(":feature-hello-api")),
+    ),
+)
+```
+
+Directory naming (includer flat names):
+
+```
+shared-kmp-library/          # suffix kmp-library
+core-kmp-api/                # suffix kmp-api
+feature/hello/impl/          # existing android impl
+```
+
+---
+
+## 10. Risks and open decisions
+
+| Risk | Mitigation |
+|------|------------|
+| AGP 9 × Kotlin 2.3 Android KMP library plugin API churn | Spike in F-107 first commit; pin exact plugin ids in PROGRESS |
+| `applyDependencies` configuration names wrong for MPP | Prefer Kotlin source set dependency API for KMP DSL |
+| Suffix explosion (`kmp-library` long names) | Accept clarity over brevity; includer already uses flat names |
+| Dual registries (Android vs KMP) and shared consumers | F-108 explicit allow-lists; never merge registries into one singleton |
+| CI without Android SDK for pure KMP tests | Keep `:kmp` unit tests pure; example with Android stays in `examples/kmp` job or application job |
+| Expect/actual overuse | Docs: prefer common expect-free design; actuals only at platform edges |
+
+**Open (resolve during F-107 spike, not by inventing a second happy path):**
+
+1. Exact Android plugin id for KMP library under AGP 9.3 (`com.android.kotlin.multiplatform.library` vs classic).
+2. Whether `androidDependencies` / `jvmDependencies` attrs ship in F-107 or wait until a consumer needs them.
+3. CI matrix row for `examples/kmp` (extend main workflow vs document manual-only until F-109).
+
+---
+
+## 11. Principles checklist
+
+| Principle | How KMP honors it |
+|-----------|-------------------|
+| Bazel-like rules | Type owns MPP plugin + platforms |
+| One global way | `kmpProjectConfiguration` platforms; no per-module target lists |
+| Explicit structure + tooling | Suffix types + matrix; fleet layout for commonMain |
+| Flat role-typed graph | `kmp-api` / `kmp-library` / `kmp-util`; no generic shared bucket |
+| Composition at roots | Apps/binaries on Android/JVM; no kmpBinary v1 |
+| Closed matrix | §6; code truth in registries + DEPENDENCY-MATRIX |
+| Portable core | Types/registry only; apply in `:kmp` |
+| No plugin shopping | Rejected shapes §3 |
+
+---
+
+## 12. See also
+
+- Implementation plan (Hermes): `.hermes/plans/*-kmp-multiplatform.md` (workspace)
+- JVM precedent: [`JVM-TARGETS.md`](JVM-TARGETS.md), `plugins/jvm/`
+- Target plugins: [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md)
+- Tickets: `TICKETS.md` § P11

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,24 @@
 
 Newest entries first.
 
+## 2026-07-25 — F-105: Kotlin Multiplatform design (plan + board)
+
+- **Ticket:** F-105 → `done` (implement F-106…F-110)
+- **Branch:** `forma/F-105-kmp-design` (from `origin/v2`)
+- **User ask:** Plan and add Kotlin multiplatform support for Gradle (Claw topic 136)
+- **Design:** [`docs/KMP-TARGETS.md`](KMP-TARGETS.md)
+  - New platform plugin `tools.forma.kmp` (parallel to `tools.forma.jvm`)
+  - Types: `kmp-api` / `kmp-library` / `kmp-util` / `kmp-test-util` (suffix-prefixed; no collision with `api`/`library`)
+  - v1 platforms: **jvm + android** only; project-global `kmpProjectConfiguration`; type owns MPP plugin
+  - Rejected: call-site `kotlin { targets { } }`, plugin shopping, restoring `androidLibrary`, `kmpImpl`/`kmpBinary` in v1
+  - Composition roots remain Android/JVM; Android/JVM registries gain consumer edges in F-108
+  - Ticket map F-106 skeleton → F-107 apply/DSL → F-108 matrices → F-109 example → F-110 docs
+- **Board:** `TICKETS.md` **P11**; VISION platform list + sequencing §8; ARCHITECTURE `:kmp` row; README link
+- **Impl plan (workspace):** `.hermes/plans/2026-07-25_092348-kmp-multiplatform.md` (local Hermes; design of record is `docs/KMP-TARGETS.md`)
+- **Code:** docs/board only this slice (no plugin module yet)
+- **Verify:** n/a product build (design)
+- **Next step:** **F-106** `:kmp` module + `KmpTargetRegistry` unit tests (Grok Build / implement PR)
+
 ## 2026-07-25 — F-099: project-global feature flags + conditional deps (GH #126)
 
 - **Ticket:** F-099 → `done` (GH #126)

--- a/docs/VISION.md
+++ b/docs/VISION.md
@@ -69,7 +69,11 @@ Concrete stacks built **on** forma-core:
    matrix; Dagger2-friendly `api`/`impl` conventions; external deps catalog
    patterns. (`androidLibrary` removed in F-063 — do not teach or reintroduce it.)
 2. **JVM** — pure JVM targets and samples reusing the same restriction model.
-3. **Bazel** — later adapter that reuses forma-core concepts (types + restrictions) rather than forking the rules engine.
+3. **Kotlin Multiplatform (KMP)** — shared `kmp-api` / `kmp-library` / `kmp-util`
+   roles via `tools.forma.kmp`; type-owned `kotlin-multiplatform`; v1 platforms
+   **jvm + android** only; composition stays at Android/JVM roots. Design:
+   [`KMP-TARGETS.md`](KMP-TARGETS.md) (F-105+).
+4. **Bazel** — later adapter that reuses forma-core concepts (types + restrictions) rather than forking the rules engine.
 
 ## Sequencing
 
@@ -80,6 +84,7 @@ Concrete stacks built **on** forma-core:
 5. **Flat-structure hardening** — remove generic targets that undermine role typing (P6 / F-060–F-063; `androidLibrary` gone).
 6. **Uniform target plugins** — Bazel-like: plugin on the **target type**, auto-apply on every call site; call sites are attributes-only; chain `withPlugin` **removed** (P7 / F-070–F-073 + F-081; [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md)).
 7. **Principle-alignment implementation** — close remaining gaps vs root principles (P8 / F-080–F-085; audit: [`PRINCIPLE-AUDIT.md`](PRINCIPLE-AUDIT.md)).
+8. **Kotlin Multiplatform** — third Gradle platform on forma-core (`tools.forma.kmp`); design F-105 ([`KMP-TARGETS.md`](KMP-TARGETS.md)); implement F-106…F-110 (jvm+android shared libraries first; no per-module target shopping).
 
 ## Working principles
 


### PR DESCRIPTION
## Summary
- Design contract for first-class **Kotlin Multiplatform** support as a third Forma Gradle platform (`tools.forma.kmp`).
- Canonical doc: `docs/KMP-TARGETS.md` — type-owned MPP, `kmp-*` suffixes, v1 **jvm + android**, closed matrix, rejected call-site target shopping.
- Board **P11** tickets **F-106…F-110**; F-105 done; **F-106** user-prioritized next.
- VISION / ARCHITECTURE / README / PROGRESS pointers.

## Non-goals (v1)
iOS/JS/Wasm, kmpBinary/kmpImpl, restoring `androidLibrary`, raw per-module `kotlin { targets }`.

## Test plan
- [x] Design-only slice (no plugin code)
- [ ] Follow-up F-106: `:kmp` skeleton + registry unit tests