### PR TITLE
F-106: tools.forma.kmp skeleton + KmpTargetRegistry

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -149,14 +149,14 @@ worker (ops); `v2`→`master` (explicit git promote only). **F-094** stays `bloc
 ## P11 — Kotlin Multiplatform (Stepan 2026-07-25)
 
 Third Gradle platform on forma-core (`tools.forma.kmp`). **Design:** [`docs/KMP-TARGETS.md`](docs/KMP-TARGETS.md).
-**User priority (2026-07-25):** implement **F-106** next (before F-100…F-104) unless a hotfix blocks.
+**User priority (2026-07-25):** implement **F-107** next (before F-100…F-104) unless a hotfix blocks.
 v1 = **jvm + android** shared libraries only; type-owned MPP; **no** per-module target shopping;
 composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
 | F-105 | done | Design KMP targets + matrix + plugin shape | `docs/KMP-TARGETS.md` — types `kmp-api`/`kmp-library`/`kmp-util`/`kmp-test-util`; `kmpProjectConfiguration`; rejected free-form `kotlin { targets }`; VISION/ARCHITECTURE/README pointers |
-| F-106 | todo | `:kmp` plugin skeleton + `KmpTargetRegistry` matrix tests | Module `plugins/kmp`, plugin id `tools.forma.kmp`, types + `registerKmpDefaults`, unit tests; no half-working public DSL until F-107 |
+| F-106 | done | `:kmp` plugin skeleton + `KmpTargetRegistry` matrix tests | Module `plugins/kmp`, plugin id `tools.forma.kmp`, types + `registerKmpDefaults`, 5 unit tests; jacoco happy-path includes `kmp/target/**`; no public DSL until F-107 |
 | F-107 | todo | Apply kotlin-multiplatform + `kmpLibrary` DSL | Feature applicator jvm+android; deps via commonMain path; spike Android KMP library plugin id under AGP 9.3; `kmpProjectConfiguration` |
 | F-108 | todo | Android/JVM consumer matrix edges → kmp.* | Extend `AndroidTargetRegistry` + `JvmTargetRegistry`; update `DEPENDENCY-MATRIX.md` from code; avoid `:kmp`→`:android` cycle |
 | F-109 | todo | Progressive example `examples/kmp/01-shared-library` | Shared `kmp-library` + JVM (and optional Android) consumer; green documented Gradle tasks |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -61,7 +61,7 @@ that compose via `includeBuild`:
 
 - `pluginManagement { includeBuild("../build-settings") }`
 - `tools.forma.includer` **0.2.0** from Portal (not local includer composite)
-- Includer discovers `:android`, `:config`, `:core`, `:deps`, `:jvm`, `:owners`, `:target`, `:validation` (F-021 `:core`; F-030 `:jvm`); **`:kmp` planned F-106** (F-105 design)
+- Includer discovers `:android`, `:config`, `:core`, `:deps`, `:jvm`, `:kmp`, `:owners`, `:target`, `:validation` (F-021 `:core`; F-030 `:jvm`; F-106 `:kmp`)
 
 ---
 
@@ -94,8 +94,8 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
         ┌───────────┼───────────────────┐
         │           │                   │
   ┌─────┴─────┐ ┌───┴────┐        ┌─────┴─────┐
-  │  android  │ │  jvm   │        │    kmp    │  F-105 design; F-106+ module
-  │  DSL+AGP  │ │ no AGP │        │  MPP DSL  │  (tools.forma.kmp)
+  │  android  │ │  jvm   │        │    kmp    │  F-106 registry; F-107+ MPP DSL
+  │  DSL+AGP  │ │ no AGP │        │  MPP     │  (tools.forma.kmp)
   └───────────┘ └────────┘        └───────────┘
 ```
 
@@ -109,7 +109,7 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
 | `:deps` | `tools.forma.deps` | `:core`, `:validation`, `:target`, `:config`, kotlin-dsl | `FormaDependency` model, `applyDependencies`, version-catalog generators |
 | `:android` | `tools.forma.android` | `:core` + all of the above + **AGP** + Kotlin GP | Target DSL; `AndroidTargetTypes` + `AndroidRestrictionKit` (F-021); content helpers call core `ContentRule` (F-022) |
 | `:jvm` | `tools.forma.jvm` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin GP (**no AGP**) | Pure JVM DSL (`api`/`impl`/`library`/`util`/`testUtil` in package `tools.forma.jvm`); `JvmTargetTypes` + `JvmTargetRegistry` (F-030) |
-| `:kmp` | `tools.forma.kmp` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin MPP GP (**no** hard dep on `:android`; AGP coords as needed for androidTarget) | **Planned F-106+** — KMP DSL (`kmpLibrary` / `kmpApi` / …); `KmpTargetTypes` + `KmpTargetRegistry`; design [`KMP-TARGETS.md`](KMP-TARGETS.md) (F-105) |
+| `:kmp` | `tools.forma.kmp` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin GP (**no** hard dep on `:android`) | **F-106:** `KmpTargetTypes` + `KmpTargetRegistry` + empty Settings plugin; DSL/MPP apply → F-107 ([`KMP-TARGETS.md`](KMP-TARGETS.md)) |
 
 `:android` compiles against **AGP 9.3.0** (aligned with sample
 `androidProjectConfiguration(agpVersion = …)` — F-018 / #182). Keep

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,20 @@
 
 Newest entries first.
 
+## 2026-07-25 — F-106: `:kmp` plugin skeleton + KmpTargetRegistry
+
+- **Ticket:** F-106 → `done` (next F-107 apply/DSL)
+- **Branch:** `forma/F-106-kmp-skeleton` (from `origin/v2` @ F-105)
+- **Code:**
+  - `plugins/kmp/` — `tools.forma.kmp` Settings plugin (empty apply), `KmpTargetTypes`, `KmpTargetRegistry` / `registerKmpDefaults` (matrix from KMP-TARGETS §6.1)
+  - Unit tests: `KmpTargetRegistryTest` (5) — register, matrix allow/deny, validator suffixes, selfValidator kmp-prefix, identity cache
+  - Jacoco happy-path includes `**/tools/forma/kmp/target/**`
+- **Docs:** ARCHITECTURE `:kmp` row live; TICKETS F-106 done
+- **Verify (real host, `source scripts/env-mac.sh`):**
+  - `plugins/`: `./gradlew :kmp:test` → **BUILD SUCCESSFUL** — 5 tests, 0 failures
+  - `plugins/`: `./gradlew test jacocoHappyPathCoverageVerification` → **BUILD SUCCESSFUL**
+- **Next step:** F-107 — kotlin-multiplatform apply + `kmpLibrary` DSL + `kmpProjectConfiguration`
+
 ## 2026-07-25 — F-105: Kotlin Multiplatform design (plan + board)
 
 - **Ticket:** F-105 → `done` (implement F-106…F-110)

--- a/plugins/buildSrc/src/main/kotlin/formaCoverage.kt
+++ b/plugins/buildSrc/src/main/kotlin/formaCoverage.kt
@@ -70,6 +70,8 @@ internal val happyPathClassIncludes =
         // F-099 pure conditional-deps resolver (applyDependencies stays out of gate)
         "**/tools/forma/deps/core/ConditionalDependency*",
         "**/tools/forma/jvm/target/**",
+        // F-106 KMP registry (MPP apply paths stay out until TestKit)
+        "**/tools/forma/kmp/target/**",
     )
 
 /** Apply Jacoco reporting to a plugins subproject (when it has Java + tests). */

--- a/plugins/kmp/build.gradle.kts
+++ b/plugins/kmp/build.gradle.kts
@@ -1,0 +1,38 @@
+@file:Suppress("UnstableApiUsage")
+
+import org.jetbrains.kotlin.gradle.tasks.KotlinCompilationTask
+
+plugins {
+    id("org.gradle.kotlin.kotlin-dsl")
+    id("com.gradle.plugin-publish")
+}
+
+formaPublishedPlugin(
+    name = "kmp",
+    description = "Kotlin Multiplatform targets for Forma (tools.forma.kmp)",
+    extraTags = listOf("kmp", "multiplatform"),
+)
+
+tasks.named("compileKotlin", KotlinCompilationTask::class.java) {
+    compilerOptions {
+        // Parity with :jvm; no special flags required for registry-only F-106.
+    }
+}
+
+dependencies {
+    // KMP platform plugin — NO hard dependency on :android (F-105).
+    // F-107 will use Kotlin MPP APIs from the embedded Kotlin Gradle plugin.
+    implementation(embeddedKotlin("gradle-plugin"))
+
+    implementation(project(":core"))
+    implementation(project(":deps"))
+    implementation(project(":validation"))
+    implementation(project(":target"))
+    implementation(project(":owners"))
+
+    testImplementation(kotlin("test"))
+}
+
+tasks.test {
+    useJUnitPlatform()
+}

--- a/plugins/kmp/src/main/java/tools/forma/kmp/plugin/FormaPlugin.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/plugin/FormaPlugin.kt
@@ -1,0 +1,19 @@
+@file:Suppress("unused")
+
+package tools.forma.kmp.plugin
+
+import org.gradle.api.Plugin
+import org.gradle.api.initialization.Settings
+
+/**
+ * Empty Settings plugin implementation to enable publishing `tools.forma.kmp`
+ * to the Gradle Plugin Portal (same pattern as :android / :jvm).
+ *
+ * Target DSL and MPP apply live in `tools.forma.kmp` package (F-107+).
+ */
+class FormaPlugin : Plugin<Settings> {
+
+    override fun apply(settings: Settings) {
+        return
+    }
+}

--- a/plugins/kmp/src/main/java/tools/forma/kmp/target/KmpTargetRegistry.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/target/KmpTargetRegistry.kt
@@ -1,0 +1,55 @@
+package tools.forma.kmp.target
+
+import tools.forma.core.target.DefaultTargetRegistry
+import tools.forma.core.target.TargetRegistration
+import tools.forma.core.target.TargetRegistry
+
+/**
+ * Singleton registry for KMP target types (F-106).
+ * Separate from AndroidTargetRegistry / JvmTargetRegistry.
+ * Use [registerKmpDefaults] to populate the restriction matrix.
+ */
+object KmpTargetRegistry : TargetRegistry by DefaultTargetRegistry()
+
+/**
+ * Register KMP target types + restriction matrix (docs/KMP-TARGETS.md §6.1).
+ *
+ * - kmp-api       → kmp-api
+ * - kmp-library   → kmp-api, kmp-library, kmp-util, kmp-test-util
+ * - kmp-util      → kmp-util
+ * - kmp-test-util → kmp-api, kmp-library, kmp-util, kmp-test-util
+ *
+ * No ContentRules in v1 (no Android res under common — enforced later if needed).
+ * Safe to call multiple times (re-register replaces).
+ */
+fun registerKmpDefaults(registry: TargetRegistry = KmpTargetRegistry) {
+    val t = KmpTargetTypes
+
+    registry.register(
+        TargetRegistration(
+            type = t.api,
+            allowedDependencies = setOf(t.api),
+        )
+    )
+
+    registry.register(
+        TargetRegistration(
+            type = t.library,
+            allowedDependencies = setOf(t.api, t.library, t.util, t.testUtil),
+        )
+    )
+
+    registry.register(
+        TargetRegistration(
+            type = t.util,
+            allowedDependencies = setOf(t.util),
+        )
+    )
+
+    registry.register(
+        TargetRegistration(
+            type = t.testUtil,
+            allowedDependencies = setOf(t.api, t.library, t.util, t.testUtil),
+        )
+    )
+}

--- a/plugins/kmp/src/main/java/tools/forma/kmp/target/KmpTargetTypes.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/target/KmpTargetTypes.kt
@@ -1,0 +1,26 @@
+package tools.forma.kmp.target
+
+import tools.forma.core.target.TargetType
+import tools.forma.core.target.targetType
+
+/**
+ * Stable TargetType instances for the Kotlin Multiplatform platform (F-105 / F-106).
+ *
+ * Suffixes are **kmp-prefixed** so they never collide with Android/JVM `api` / `library` /
+ * `util` rows under suffix-based name matching.
+ *
+ * See `docs/KMP-TARGETS.md`.
+ */
+object KmpTargetTypes {
+    /** Shared public contracts (expect/actual-friendly). */
+    val api: TargetType = targetType("kmp.api", "kmp-api")
+
+    /** Shared multiplatform library (default workhorse). */
+    val library: TargetType = targetType("kmp.library", "kmp-library")
+
+    /** Shared utilities / extensions. */
+    val util: TargetType = targetType("kmp.util", "kmp-util")
+
+    /** Shared test helpers (commonTest + platform tests). */
+    val testUtil: TargetType = targetType("kmp.test-util", "kmp-test-util")
+}

--- a/plugins/kmp/src/test/java/tools/forma/kmp/target/KmpTargetRegistryTest.kt
+++ b/plugins/kmp/src/test/java/tools/forma/kmp/target/KmpTargetRegistryTest.kt
@@ -1,0 +1,118 @@
+package tools.forma.kmp.target
+
+import tools.forma.core.target.TargetRef
+import tools.forma.core.validation.FormaValidationException
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertSame
+import kotlin.test.assertTrue
+
+/**
+ * F-106: KMP matrix + registry behavior (no MPP apply yet).
+ */
+class KmpTargetRegistryTest {
+
+    private data class TestRef(override val name: String) : TargetRef
+
+    @BeforeTest
+    fun setup() {
+        registerKmpDefaults()
+    }
+
+    @Test
+    fun `all four kmp types are registered by id`() {
+        val t = KmpTargetTypes
+        assertEquals(t.api, KmpTargetRegistry.get("kmp.api"))
+        assertEquals(t.library, KmpTargetRegistry.get("kmp.library"))
+        assertEquals(t.util, KmpTargetRegistry.get("kmp.util"))
+        assertEquals(t.testUtil, KmpTargetRegistry.get("kmp.test-util"))
+        assertEquals(4, KmpTargetRegistry.all().size)
+    }
+
+    @Test
+    fun `restriction graph encodes kmp matrix from design doc`() {
+        val t = KmpTargetTypes
+        val g = KmpTargetRegistry.restrictionGraph()
+
+        // kmp-api: only other kmp-api
+        assertTrue(g.isAllowed(t.api, t.api))
+        assertFalse(g.isAllowed(t.api, t.library))
+        assertFalse(g.isAllowed(t.api, t.util))
+        assertFalse(g.isAllowed(t.api, t.testUtil))
+
+        // kmp-library: layered shared stack + contracts + utils
+        assertTrue(g.isAllowed(t.library, t.api))
+        assertTrue(g.isAllowed(t.library, t.library))
+        assertTrue(g.isAllowed(t.library, t.util))
+        assertTrue(g.isAllowed(t.library, t.testUtil))
+
+        // kmp-util: only util peers
+        assertTrue(g.isAllowed(t.util, t.util))
+        assertFalse(g.isAllowed(t.util, t.api))
+        assertFalse(g.isAllowed(t.util, t.library))
+        assertFalse(g.isAllowed(t.util, t.testUtil))
+
+        // kmp-test-util: may see contracts + library + util + peers
+        assertTrue(g.isAllowed(t.testUtil, t.api))
+        assertTrue(g.isAllowed(t.testUtil, t.library))
+        assertTrue(g.isAllowed(t.testUtil, t.util))
+        assertTrue(g.isAllowed(t.testUtil, t.testUtil))
+    }
+
+    @Test
+    fun `validatorFor rejects disallowed project suffixes`() {
+        val t = KmpTargetTypes
+        val apiV = KmpTargetRegistry.validatorFor(t.api)
+        apiV.validate(TestRef("core-kmp-api"))
+        assertFailsWith<FormaValidationException> {
+            apiV.validate(TestRef("shared-kmp-library"))
+        }
+        assertFailsWith<FormaValidationException> {
+            apiV.validate(TestRef("feature-api")) // plain android/jvm api suffix
+        }
+
+        val libV = KmpTargetRegistry.validatorFor(t.library)
+        libV.validate(TestRef("shared-kmp-library"))
+        libV.validate(TestRef("core-kmp-api"))
+        libV.validate(TestRef("net-kmp-util"))
+        assertFailsWith<FormaValidationException> {
+            libV.validate(TestRef("feature-impl"))
+        }
+
+        val utilV = KmpTargetRegistry.validatorFor(t.util)
+        utilV.validate(TestRef("shared-kmp-util"))
+        assertFailsWith<FormaValidationException> {
+            utilV.validate(TestRef("shared-kmp-library"))
+        }
+    }
+
+    @Test
+    fun `selfValidator accepts kmp-prefixed suffixes only`() {
+        val t = KmpTargetTypes
+        KmpTargetRegistry.selfValidator(t.api).validate(TestRef("kmp-api"))
+        KmpTargetRegistry.selfValidator(t.api).validate(TestRef("core-kmp-api"))
+        assertFailsWith<FormaValidationException> {
+            KmpTargetRegistry.selfValidator(t.api).validate(TestRef("feature-api"))
+        }
+        KmpTargetRegistry.selfValidator(t.library).validate(TestRef("shared-kmp-library"))
+        KmpTargetRegistry.selfValidator(t.util).validate(TestRef("tools-kmp-util"))
+        KmpTargetRegistry.selfValidator(t.testUtil).validate(TestRef("shared-kmp-test-util"))
+        assertFailsWith<FormaValidationException> {
+            KmpTargetRegistry.selfValidator(t.library).validate(TestRef("common-library"))
+        }
+    }
+
+    @Test
+    fun `validatorFor is identity cached for same type`() {
+        val t = KmpTargetTypes
+        val v1 = KmpTargetRegistry.validatorFor(t.library)
+        val v2 = KmpTargetRegistry.validatorFor(t.library)
+        assertSame(v1, v2)
+        val s1 = KmpTargetRegistry.selfValidator(t.api)
+        val s2 = KmpTargetRegistry.selfValidator(t.api)
+        assertSame(s1, s2)
+    }
+}


### PR DESCRIPTION
## Summary
- New `plugins/kmp` → plugin id **`tools.forma.kmp`**
- `KmpTargetTypes` / `KmpTargetRegistry` / `registerKmpDefaults` (matrix from `docs/KMP-TARGETS.md` §6.1)
- 5 unit tests (`KmpTargetRegistryTest`)
- Jacoco happy-path includes `kmp/target/**`
- Board: F-106 done; next **F-107** (MPP apply + `kmpLibrary`)

## Test plan
- [x] `cd plugins && ./gradlew :kmp:test` — 5 passed
- [x] `./gradlew test jacocoHappyPathCoverageVerification` — BUILD SUCCESSFUL