### PR TITLE
F-107: kmpLibrary DSL + multiplatform apply + kmpProjectConfiguration

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -157,7 +157,7 @@ composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 |----|--------|-------|-------|
 | F-105 | done | Design KMP targets + matrix + plugin shape | `docs/KMP-TARGETS.md` — types `kmp-api`/`kmp-library`/`kmp-util`/`kmp-test-util`; `kmpProjectConfiguration`; rejected free-form `kotlin { targets }`; VISION/ARCHITECTURE/README pointers |
 | F-106 | done | `:kmp` plugin skeleton + `KmpTargetRegistry` matrix tests | Module `plugins/kmp`, plugin id `tools.forma.kmp`, types + `registerKmpDefaults`, 5 unit tests; jacoco happy-path includes `kmp/target/**`; no public DSL until F-107 |
-| F-107 | todo | Apply kotlin-multiplatform + `kmpLibrary` DSL | Feature applicator jvm+android; deps via commonMain path; spike Android KMP library plugin id under AGP 9.3; `kmpProjectConfiguration` |
+| F-107 | done | Apply kotlin-multiplatform + `kmpLibrary` DSL | `kmpProjectConfiguration` + feature applicator (`com.android.kotlin.multiplatform.library` + jvm); `kmpLibrary`/`kmpApi`/`kmpUtil`/`kmpTestUtil`; commonMain deps; unit tests; plugins jacoco green |
 | F-108 | todo | Android/JVM consumer matrix edges → kmp.* | Extend `AndroidTargetRegistry` + `JvmTargetRegistry`; update `DEPENDENCY-MATRIX.md` from code; avoid `:kmp`→`:android` cycle |
 | F-109 | todo | Progressive example `examples/kmp/01-shared-library` | Shared `kmp-library` + JVM (and optional Android) consumer; green documented Gradle tasks |
 | F-110 | todo | KMP user docs + agent skill + curriculum | `KMP-GETTING-STARTED.md`, `examples/agent-skills/forma-kmp-targets.md`, PROGRESSIVE-EXAMPLES ladder, README |

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -94,7 +94,7 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
         ┌───────────┼───────────────────┐
         │           │                   │
   ┌─────┴─────┐ ┌───┴────┐        ┌─────┴─────┐
-  │  android  │ │  jvm   │        │    kmp    │  F-106 registry; F-107+ MPP DSL
+  │  android  │ │  jvm   │        │    kmp    │  F-107 kmpLibrary + MPP apply
   │  DSL+AGP  │ │ no AGP │        │  MPP     │  (tools.forma.kmp)
   └───────────┘ └────────┘        └───────────┘
 ```
@@ -109,7 +109,7 @@ Group/version (root `plugins/build.gradle.kts`): **`tools.forma` / `0.1.3`**.
 | `:deps` | `tools.forma.deps` | `:core`, `:validation`, `:target`, `:config`, kotlin-dsl | `FormaDependency` model, `applyDependencies`, version-catalog generators |
 | `:android` | `tools.forma.android` | `:core` + all of the above + **AGP** + Kotlin GP | Target DSL; `AndroidTargetTypes` + `AndroidRestrictionKit` (F-021); content helpers call core `ContentRule` (F-022) |
 | `:jvm` | `tools.forma.jvm` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin GP (**no AGP**) | Pure JVM DSL (`api`/`impl`/`library`/`util`/`testUtil` in package `tools.forma.jvm`); `JvmTargetTypes` + `JvmTargetRegistry` (F-030) |
-| `:kmp` | `tools.forma.kmp` | `:core`, `:deps`, `:validation`, `:target`, `:owners` + Kotlin GP (**no** hard dep on `:android`) | **F-106:** `KmpTargetTypes` + `KmpTargetRegistry` + empty Settings plugin; DSL/MPP apply → F-107 ([`KMP-TARGETS.md`](KMP-TARGETS.md)) |
+| `:kmp` | `tools.forma.kmp` | `:core`, `:deps`, `:config`, `:validation`, `:target`, `:owners` + Kotlin GP; `compileOnly` AGP (**no** `:android`) | **F-107:** `kmpProjectConfiguration` + `kmpLibrary`/`kmpApi`/`kmpUtil`/`kmpTestUtil`; MPP + `com.android.kotlin.multiplatform.library`; commonMain deps ([`KMP-TARGETS.md`](KMP-TARGETS.md)) |
 
 `:android` compiles against **AGP 9.3.0** (aligned with sample
 `androidProjectConfiguration(agpVersion = …)` — F-018 / #182). Keep

--- a/docs/KMP-TARGETS.md
+++ b/docs/KMP-TARGETS.md
@@ -146,26 +146,40 @@ suffix-based).
 
 | Platform | Kotlin target | Android wiring |
 |----------|---------------|----------------|
-| **JVM** | `jvm()` | n/a |
-| **Android** | `androidTarget()` (or current Kotlin 2.3 / AGP 9 recommended API) | **Android KMP Library** plugin path preferred: `com.android.kotlin.multiplatform.library` when supported by pinned AGP; fallback documented in F-107 if spike forces classic `com.android.library` + KMP |
+| **JVM** | `jvm()` with `compilerOptions.jvmTarget` from settings (default `"11"`) | n/a |
+| **Android** | Target created by AGP KMP library plugin (extension on `kotlin { }`) | **Shipped (F-107 spike):** `com.android.kotlin.multiplatform.library` |
+
+#### Android plugin id — F-107 spike result (AGP 9.3.0 / Kotlin 2.3.21)
+
+| Choice | Value |
+|--------|--------|
+| **Plugin id (apply)** | `com.android.kotlin.multiplatform.library` |
+| **Implementation class** | `com.android.build.gradle.api.KotlinMultiplatformAndroidPlugin` |
+| **Classpath coordinate** | `com.android.tools.build:gradle:<agpVersion>` (same as `androidProjectConfiguration`) |
+| **Confirmed in** | AGP 9.3.0 jar `META-INF/gradle-plugins/com.android.kotlin.multiplatform.library.properties` |
+| **Classic fallback** | **Not used.** `com.android.library` + `androidTarget()` is rejected for the happy path. |
+| **Extension on `kotlin { }`** | Prefer name `android`, then `androidLibrary` (AGP registers both eras; Forma configures via extension lookup + reflective `namespace` / `compileSdk` / `minSdk`) |
+| **SDK source of truth** | `androidProjectConfiguration` → `AndroidProjectSettings` (minSdk / compileSdk). Android platform without Android settings → fail-fast at KMP DSL apply. |
+| **`:kmp` → `:android`** | **Forbidden.** Applicator uses string plugin ids + reflection; `compileOnly` AGP only. |
 
 **Single project-global default** (both on):
 
 ```kotlin
-// Conceptual — names finalized in F-106/F-107
-kmpProjectConfiguration(
-    project = rootProject,
-    // Platforms are NOT optional per module in the happy path:
-    platforms = KmpPlatforms(jvm = true, android = true),
-    // Android SDK / JVM target pulled from existing AndroidProjectSettings when android platform on,
-    // or minimal kmp-local mirrors when used from a pure KMP+JVM tree without full Android plugin.
-    jvmTarget = "11",
-)
+// Root buildscript — ScriptHandlerScope (parallel to androidProjectConfiguration)
+buildscript {
+    androidProjectConfiguration(project = rootProject, agpVersion = "9.3.0", /* … */)
+    kmpProjectConfiguration(
+        project = rootProject,
+        // Platforms are NOT optional per module in the happy path:
+        platforms = KmpPlatforms(jvm = true, android = true), // defaults
+        jvmTarget = "11",
+    )
+}
 ```
 
 **One global way:** every built-in KMP type receives the same platform set from
 `kmpProjectConfiguration` (or defaults if configuration is implicit on first DSL use — parity with
-`registerJvmDefaults()`).
+`registerJvmDefaults()`). Pure KMP+JVM trees: `platforms = KmpPlatforms(jvm = true, android = false)`.
 
 **Path B later (not v1):** `deriveTargetType` + `iosSharedLibrary` that adds iOS platforms on a
 **derived type** only — still no per-call-site target list.
@@ -390,10 +404,10 @@ feature/hello/impl/          # existing android impl
 | CI without Android SDK for pure KMP tests | Keep `:kmp` unit tests pure; example with Android stays in `examples/kmp` job or application job |
 | Expect/actual overuse | Docs: prefer common expect-free design; actuals only at platform edges |
 
-**Open (resolve during F-107 spike, not by inventing a second happy path):**
+**Open / resolved:**
 
-1. Exact Android plugin id for KMP library under AGP 9.3 (`com.android.kotlin.multiplatform.library` vs classic).
-2. Whether `androidDependencies` / `jvmDependencies` attrs ship in F-107 or wait until a consumer needs them.
+1. ~~Exact Android plugin id for KMP library under AGP 9.3~~ → **Resolved F-107:** `com.android.kotlin.multiplatform.library` (see §4.3).
+2. Whether `androidDependencies` / `jvmDependencies` attrs ship in F-107 or wait until a consumer needs them → **Deferred** (KDoc on `kmpLibrary`; commonMain/commonTest only in v1).
 3. CI matrix row for `examples/kmp` (extend main workflow vs document manual-only until F-109).
 
 ---

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest entries first.
 
+## 2026-07-25 — F-107: kmpLibrary DSL + multiplatform apply + kmpProjectConfiguration
+
+- **Ticket:** F-107 → `done` (next F-108 consumer matrix edges)
+- **Branch:** `forma/F-107-kmp-apply` (from `origin/v2` @ F-106)
+- **Code (`plugins/kmp/`):**
+  - `kmpProjectConfiguration` (`ScriptHandlerScope`) — registers `registerKmpDefaults()`, stores `KmpProjectSettings` (platforms jvm+android default **true**, jvmTarget `"11"`), puts Kotlin MPP (+ AGP when android) on **buildscript classpath only**
+  - Feature applicator `applyKotlinMultiplatform` — applies `org.jetbrains.kotlin.multiplatform`; when android: `com.android.kotlin.multiplatform.library` + reflective namespace/compileSdk/minSdk from `AndroidProjectSettings`; jvm() + jvmTarget; fail-fast if android on without `androidProjectConfiguration`
+  - `applyKmpDependencies` — commonMain / commonTest via Kotlin source-set API + same project-dep validators as `applyDependencies`
+  - Public DSL: `kmpLibrary` / `kmpApi` / `kmpUtil` / `kmpTestUtil` (Unit return, attributes only; layout with `requirePackageSourceDir=false` for commonMain until F-109)
+  - **No** `:kmp` → `:android` (cycle rule); `implementation(project(":config"))` + `compileOnly` AGP only
+  - Unit tests: settings store (4) + feature resolution/plugin ids (6) + existing registry (5) = **15**
+  - Jacoco happy-path includes `kmp/settings/**` + `KmpPluginIds*` / `KmpFeatureResolution*` (not Project apply paths)
+- **Android plugin spike (AGP 9.3.0):** **preferred path works** — plugin id `com.android.kotlin.multiplatform.library` present in AGP jar; classic `com.android.library` fallback **not** used. Documented in `docs/KMP-TARGETS.md` §4.3.
+- **Open decision #2:** `androidDependencies` / `jvmDependencies` attrs **deferred** (KDoc on DSL).
+- **Docs:** KMP-TARGETS §4.3 spike result; TICKETS F-107 done
+- **Verify (real host, `source scripts/env-mac.sh`):**
+  - `plugins/`: `./gradlew :kmp:test` → **BUILD SUCCESSFUL** — 15 tests, 0 failures
+  - `plugins/`: `./gradlew test jacocoHappyPathCoverageVerification` → **BUILD SUCCESSFUL**
+- **Next step:** F-108 — Android/JVM registry consumer edges → kmp.*
+
 ## 2026-07-25 — F-106: `:kmp` plugin skeleton + KmpTargetRegistry
 
 - **Ticket:** F-106 → `done` (next F-107 apply/DSL)

--- a/plugins/buildSrc/src/main/kotlin/formaCoverage.kt
+++ b/plugins/buildSrc/src/main/kotlin/formaCoverage.kt
@@ -70,8 +70,11 @@ internal val happyPathClassIncludes =
         // F-099 pure conditional-deps resolver (applyDependencies stays out of gate)
         "**/tools/forma/deps/core/ConditionalDependency*",
         "**/tools/forma/jvm/target/**",
-        // F-106 KMP registry (MPP apply paths stay out until TestKit)
+        // F-106/F-107 KMP pure registry + settings + resolution (Project apply paths stay out)
         "**/tools/forma/kmp/target/**",
+        "**/tools/forma/kmp/settings/**",
+        "**/tools/forma/kmp/feature/KmpPluginIds*",
+        "**/tools/forma/kmp/feature/KmpFeatureResolution*",
     )
 
 /** Apply Jacoco reporting to a plugins subproject (when it has Java + tests). */

--- a/plugins/kmp/build.gradle.kts
+++ b/plugins/kmp/build.gradle.kts
@@ -15,13 +15,12 @@ formaPublishedPlugin(
 
 tasks.named("compileKotlin", KotlinCompilationTask::class.java) {
     compilerOptions {
-        // Parity with :jvm; no special flags required for registry-only F-106.
+        // Parity with :jvm
     }
 }
 
 dependencies {
-    // KMP platform plugin — NO hard dependency on :android (F-105).
-    // F-107 will use Kotlin MPP APIs from the embedded Kotlin Gradle plugin.
+    // KMP platform plugin — NO hard dependency on :android (F-105 / F-107 cycle rule).
     implementation(embeddedKotlin("gradle-plugin"))
 
     implementation(project(":core"))
@@ -29,6 +28,12 @@ dependencies {
     implementation(project(":validation"))
     implementation(project(":target"))
     implementation(project(":owners"))
+    // KmpProjectConfiguration reads FormaSettingsStore for AGP alignment (compileOnly cycle-safe)
+    implementation(project(":config"))
+
+    // Optional typed AGP surfaces if needed later; apply path uses string plugin ids + reflection
+    // so :kmp never implementation(project(":android")).
+    compileOnly("com.android.tools.build:gradle:9.3.0")
 
     testImplementation(kotlin("test"))
 }

--- a/plugins/kmp/src/main/java/tools/forma/kmp/feature/KmpFeature.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/feature/KmpFeature.kt
@@ -1,0 +1,171 @@
+package tools.forma.kmp.feature
+
+import org.gradle.api.GradleException
+import org.gradle.api.Project
+import org.gradle.api.plugins.ExtensionAware
+import org.gradle.kotlin.dsl.apply
+import org.jetbrains.kotlin.gradle.dsl.JvmTarget
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import tools.forma.config.FormaSettingsStore
+import tools.forma.kmp.settings.KmpPlatforms
+import tools.forma.kmp.settings.KmpProjectSettings
+import tools.forma.kmp.settings.KmpSettingsStore
+
+/**
+ * Plugin ids owned by the KMP feature applicator (F-107 spike under AGP 9.3 / Kotlin 2.3).
+ *
+ * Documented in docs/KMP-TARGETS.md §4.3.
+ */
+object KmpPluginIds {
+    /** Kotlin Multiplatform Gradle plugin. */
+    const val KOTLIN_MULTIPLATFORM: String = "org.jetbrains.kotlin.multiplatform"
+
+    /**
+     * Preferred Android wiring under AGP 9.3: dedicated KMP library plugin
+     * (not classic `com.android.library`).
+     *
+     * Confirmed present in `com.android.tools.build:gradle:9.3.0`
+     * (`META-INF/gradle-plugins/com.android.kotlin.multiplatform.library.properties`).
+     */
+    const val ANDROID_KMP_LIBRARY: String = "com.android.kotlin.multiplatform.library"
+}
+
+/**
+ * Pure resolution of effective platforms / jvmTarget for unit tests without a Project.
+ */
+object KmpFeatureResolution {
+    fun resolveSettings(
+        store: KmpProjectSettings? = KmpSettingsStore.settingsOrNull()
+    ): KmpProjectSettings = store ?: KmpProjectSettings()
+
+    fun platforms(settings: KmpProjectSettings = resolveSettings()): KmpPlatforms =
+        settings.platforms
+
+    fun jvmTarget(settings: KmpProjectSettings = resolveSettings()): String = settings.jvmTarget
+
+    /**
+     * Fail-fast precondition for the android platform.
+     *
+     * @return null if ok; error message if android cannot be applied
+     */
+    fun androidApplyErrorOrNull(
+        settings: KmpProjectSettings,
+        androidSettingsStored: Boolean,
+    ): String? {
+        if (!settings.platforms.android) return null
+        if (!androidSettingsStored) {
+            return "KMP android platform is enabled but androidProjectConfiguration was not called. " +
+                "Either configure Android first (recommended monorepo path), or set " +
+                "platforms = KmpPlatforms(jvm = true, android = false) in kmpProjectConfiguration " +
+                "for a pure KMP+JVM tree."
+        }
+        return null
+    }
+}
+
+/**
+ * Applies Kotlin Multiplatform (+ optional Android KMP library) and configures platforms
+ * from stored [KmpProjectSettings].
+ *
+ * Call from KMP target DSL after self-validation. Does **not** depend on the `:android`
+ * project — uses string plugin ids and reflective AGP extension configuration.
+ *
+ * @param packageName Forma package / Android namespace for the android KMP library target
+ */
+fun Project.applyKotlinMultiplatform(packageName: String) {
+    val settings = KmpSettingsStore.settingsOrDefaults()
+    // First DSL use without kmpProjectConfiguration: persist defaults so later reads agree.
+    if (!KmpSettingsStore.isSettingsStored) {
+        KmpSettingsStore.store(settings)
+    }
+
+    if (settings.platforms.android) {
+        KmpFeatureResolution.androidApplyErrorOrNull(
+                settings = settings,
+                androidSettingsStored = FormaSettingsStore.isSettingsStored,
+            )
+            ?.let { throw GradleException(it) }
+    }
+
+    apply(plugin = KmpPluginIds.KOTLIN_MULTIPLATFORM)
+
+    if (settings.platforms.android) {
+        try {
+            apply(plugin = KmpPluginIds.ANDROID_KMP_LIBRARY)
+        } catch (err: Exception) {
+            throw GradleException(
+                "KMP android platform is enabled but plugin " +
+                    "'${KmpPluginIds.ANDROID_KMP_LIBRARY}' could not be applied. " +
+                    "Ensure AGP is on the buildscript classpath via " +
+                    "androidProjectConfiguration(agpVersion=…) and/or " +
+                    "kmpProjectConfiguration(agpVersion=…). " +
+                    "Preferred plugin id (AGP 9.3): ${KmpPluginIds.ANDROID_KMP_LIBRARY}. " +
+                    "Cause: ${err.message}",
+                err,
+            )
+        }
+        configureAndroidKmpLibrary(packageName)
+    }
+
+    val kotlinExt =
+        extensions.getByType(KotlinMultiplatformExtension::class.java)
+    if (settings.platforms.jvm) {
+        kotlinExt.jvm {
+            compilerOptions.jvmTarget.set(JvmTarget.fromTarget(settings.jvmTarget))
+        }
+    }
+    // commonMain / commonTest (+ platform mains) come from the KMP plugin and
+    // target presets — do not force src/main/kotlin.
+}
+
+/**
+ * Configure the Android KMP library extension added on the Kotlin multiplatform extension
+ * by [KmpPluginIds.ANDROID_KMP_LIBRARY].
+ *
+ * Extension name under AGP 9.3: tries `android` then `androidLibrary`
+ * (AGP KotlinMultiplatformAndroidPlugin constants).
+ */
+private fun Project.configureAndroidKmpLibrary(packageName: String) {
+    val androidSettings = FormaSettingsStore.settings
+    val kotlinExt =
+        extensions.findByType(KotlinMultiplatformExtension::class.java)
+            ?: throw GradleException(
+                "Kotlin multiplatform extension not found after plugin apply"
+            )
+
+    val host = kotlinExt as ExtensionAware
+    val androidExt =
+        host.extensions.findByName("android")
+            ?: host.extensions.findByName("androidLibrary")
+            ?: throw GradleException(
+                "Android KMP library extension not found on kotlin { } after applying " +
+                    "'${KmpPluginIds.ANDROID_KMP_LIBRARY}'. Expected extension name 'android' " +
+                    "or 'androidLibrary'."
+            )
+
+    configureAndroidExtensionReflective(
+        androidExt = androidExt,
+        packageName = packageName,
+        compileSdk = androidSettings.compileSdk,
+        minSdk = androidSettings.minSdk,
+    )
+}
+
+private fun configureAndroidExtensionReflective(
+    androidExt: Any,
+    packageName: String,
+    compileSdk: Int,
+    minSdk: Int,
+) {
+    fun invokeSetter(methodName: String, value: Any?) {
+        val method =
+            androidExt.javaClass.methods.find {
+                it.name == methodName && it.parameterTypes.size == 1
+            } ?: return
+        method.invoke(androidExt, value)
+    }
+
+    invokeSetter("setNamespace", packageName)
+    invokeSetter("setCompileSdk", compileSdk)
+    invokeSetter("setMinSdk", minSdk)
+}

--- a/plugins/kmp/src/main/java/tools/forma/kmp/feature/applyKmpDependencies.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/feature/applyKmpDependencies.kt
@@ -1,0 +1,135 @@
+package tools.forma.kmp.feature
+
+import forEach
+import org.gradle.api.Project
+import org.gradle.kotlin.dsl.apply
+import org.jetbrains.kotlin.gradle.dsl.KotlinMultiplatformExtension
+import org.jetbrains.kotlin.gradle.plugin.KotlinDependencyHandler
+import org.jetbrains.kotlin.gradle.plugin.KotlinSourceSet
+import tools.forma.config.FormaSettingsStore
+import tools.forma.deps.core.CompileOnly
+import tools.forma.deps.core.ConfigurationType
+import tools.forma.deps.core.EmptyDependency
+import tools.forma.deps.core.FormaDependency
+import tools.forma.deps.core.Implementation
+import tools.forma.deps.core.RuntimeOnly
+import tools.forma.deps.core.TargetSpec
+import tools.forma.deps.core.resolveFeatureFlags
+import tools.forma.validation.Validator
+
+/**
+ * Apply Forma dependencies onto KMP **commonMain** / **commonTest** via the Kotlin
+ * source-set dependency API (design §6.3 option 2).
+ *
+ * Project-dep suffix validation matches [tools.forma.deps.core.applyDependencies]
+ * (including F-090 exclusions). Does **not** use bare `implementation` configuration
+ * names that break MPP.
+ *
+ * - [dependencies] → commonMain
+ * - [testDependencies] → commonTest
+ *
+ * Platform-specific attrs (`androidDependencies` / `jvmDependencies`) deferred — see
+ * KDoc on [tools.forma.kmp.kmpLibrary] (open decision #2).
+ */
+fun Project.applyKmpDependencies(
+    validator: Validator,
+    dependencies: FormaDependency = EmptyDependency,
+    testDependencies: FormaDependency = EmptyDependency,
+) {
+    if (dependencies === EmptyDependency && testDependencies === EmptyDependency) {
+        return
+    }
+
+    val featureFlags = FormaSettingsStore.featureFlagsOrEmpty()
+    val resolvedDependencies = dependencies.resolveFeatureFlags(featureFlags)
+    val resolvedTestDependencies = testDependencies.resolveFeatureFlags(featureFlags)
+
+    if (
+        resolvedDependencies === EmptyDependency &&
+            resolvedTestDependencies === EmptyDependency
+    ) {
+        return
+    }
+
+    val kotlinExt =
+        extensions.findByType(KotlinMultiplatformExtension::class.java)
+            ?: error(
+                "applyKmpDependencies requires org.jetbrains.kotlin.multiplatform " +
+                    "(call applyKotlinMultiplatform first)"
+            )
+
+    val appliedPlugins = mutableSetOf<String>()
+    val hasPluginDeps = FormaSettingsStore.dependencyPlugins.isNotEmpty()
+
+    fun validateProjectDep(spec: TargetSpec) {
+        val depProject = spec.target.project
+        if (
+            !FormaSettingsStore.isExcludedFromDependencyValidation(
+                projectName = depProject.name,
+                projectPath = depProject.path,
+            )
+        ) {
+            validator.validate(spec.target)
+        }
+    }
+
+    fun KotlinDependencyHandler.addConfig(config: ConfigurationType, notation: Any) {
+        when (config) {
+            is Implementation -> implementation(notation)
+            is CompileOnly -> compileOnly(notation)
+            is RuntimeOnly -> runtimeOnly(notation)
+            else -> implementation(notation)
+        }
+    }
+
+    fun wireSourceSet(
+        sourceSetName: String,
+        dep: FormaDependency,
+        validateProjects: Boolean,
+    ) {
+        if (dep === EmptyDependency) return
+        kotlinExt.sourceSets.named(sourceSetName).configure {
+            dependencies {
+                dep.forEach(
+                    nameAction = { spec ->
+                        val plugin =
+                            if (hasPluginDeps) FormaSettingsStore.pluginFor(spec.name) else null
+                        if (plugin != null) {
+                            val pluginName = plugin.plugin.get().pluginId.split(":")[0]
+                            if (appliedPlugins.add(pluginName)) {
+                                apply(plugin = pluginName)
+                            }
+                            implementation(spec.name)
+                        } else {
+                            addConfig(spec.config, spec.name)
+                        }
+                    },
+                    targetAction = { spec ->
+                        if (validateProjects) {
+                            validateProjectDep(spec)
+                        }
+                        addConfig(spec.config, spec.target.project)
+                    },
+                    fileAction = { spec ->
+                        addConfig(spec.config, files(spec.file))
+                    },
+                    platformAction = { spec ->
+                        // KGP 2.3 deprecates KotlinDependencyHandler.platform — use Gradle's BOM helper.
+                        implementation(project.dependencies.platform(spec.name))
+                    },
+                )
+            }
+        }
+    }
+
+    wireSourceSet(
+        sourceSetName = KotlinSourceSet.COMMON_MAIN_SOURCE_SET_NAME,
+        dep = resolvedDependencies,
+        validateProjects = true,
+    )
+    wireSourceSet(
+        sourceSetName = KotlinSourceSet.COMMON_TEST_SOURCE_SET_NAME,
+        dep = resolvedTestDependencies,
+        validateProjects = false,
+    )
+}

--- a/plugins/kmp/src/main/java/tools/forma/kmp/kmpProjectConfiguration.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/kmpProjectConfiguration.kt
@@ -1,0 +1,127 @@
+package tools.forma.kmp
+
+import org.gradle.api.Project
+import org.gradle.api.artifacts.dsl.RepositoryHandler
+import org.gradle.api.provider.Provider
+import org.gradle.kotlin.dsl.ScriptHandlerScope
+import org.gradle.kotlin.dsl.embeddedKotlinVersion
+import org.gradle.kotlin.dsl.repositories
+import org.gradle.plugin.use.PluginDependency
+import tools.forma.config.FormaSettingsStore
+import tools.forma.kmp.settings.DEFAULT_KMP_JVM_TARGET
+import tools.forma.kmp.settings.KmpPlatforms
+import tools.forma.kmp.settings.KmpProjectSettings
+import tools.forma.kmp.settings.KmpSettingsStore
+import tools.forma.kmp.target.registerKmpDefaults
+
+/**
+ * Single project-global entry for Kotlin Multiplatform configuration (F-107 / F-082 spirit).
+ *
+ * Call once from the **root** `build.gradle.kts` inside `buildscript { }`:
+ *
+ * ```kotlin
+ * buildscript {
+ *     // When android platform is on (default), prefer configuring Android first so AGP
+ *     // version aligns automatically:
+ *     // androidProjectConfiguration(project = rootProject, agpVersion = "9.3.0", ...)
+ *     kmpProjectConfiguration(project = rootProject)
+ * }
+ * ```
+ *
+ * What it does:
+ * - Registers [registerKmpDefaults] (KMP restriction matrix)
+ * - Stores [KmpProjectSettings] (platforms jvm+android default **true**, jvmTarget `"11"`)
+ * - Puts Kotlin Multiplatform Gradle plugin on the **buildscript classpath only**
+ * - When [KmpPlatforms.android] is true: puts AGP (`com.android.tools.build:gradle`) on the
+ *   classpath so `com.android.kotlin.multiplatform.library` can be applied by the feature
+ *   applicator — **not** applied here
+ *
+ * **Classpath only — no module apply.** Modules receive plugins via KMP target DSL
+ * (`kmpLibrary`, …), never via free-form plugin id lists at call sites.
+ *
+ * Pure KMP+JVM trees: pass `platforms = KmpPlatforms(jvm = true, android = false)`.
+ * Android platform without AGP available fails fast when a KMP DSL applies the android target.
+ *
+ * @param project root project (reserved for future root tasks; registry is process-wide)
+ * @param platforms fleet-wide platform set (not per-module)
+ * @param jvmTarget Kotlin/JVM bytecode level for the jvm() target
+ * @param kotlinVersion Kotlin Gradle plugin coordinate version (defaults to embedded)
+ * @param agpVersion AGP version when android platform on; defaults to Android settings when
+ *   `androidProjectConfiguration` already ran, else must be set explicitly if android is on
+ *   and no Android settings exist (classpath still optional until apply)
+ * @param extraPlugins additional buildscript classpath jars/providers only
+ */
+fun ScriptHandlerScope.kmpProjectConfiguration(
+    project: Project,
+    platforms: KmpPlatforms = KmpPlatforms(jvm = true, android = true),
+    jvmTarget: String = DEFAULT_KMP_JVM_TARGET,
+    kotlinVersion: String = embeddedKotlinVersion,
+    agpVersion: String? = null,
+    extraPlugins: List<Any> = emptyList(),
+) {
+    @Suppress("UNUSED_VARIABLE")
+    val root = project // keep API parallel to androidProjectConfiguration(project=…)
+
+    val resolvedAgpVersion =
+        agpVersion
+            ?: if (FormaSettingsStore.isSettingsStored) {
+                FormaSettingsStore.settings.agpVersion
+            } else {
+                null
+            }
+
+    val classpathDeps = mutableListOf<Any>()
+    // Kotlin MPP plugin (same artifact as kotlin-jvm; multiplatform id lives here).
+    classpathDeps.add("org.jetbrains.kotlin:kotlin-gradle-plugin:$kotlinVersion")
+    if (platforms.android) {
+        if (resolvedAgpVersion != null) {
+            // Same AGP coordinate as androidProjectConfiguration — brings
+            // com.android.kotlin.multiplatform.library plugin id onto the classpath.
+            classpathDeps.add("com.android.tools.build:gradle:$resolvedAgpVersion")
+        }
+        // If AGP version still unknown, classpath may already include AGP from a prior
+        // androidProjectConfiguration in the same buildscript block (order-dependent).
+        // Apply-time checks in the feature applicator fail fast if the plugin is missing.
+    }
+    classpathDeps.addAll(extraPlugins)
+
+    kmpBuildscriptClasspath(classpathDeps)
+
+    val configuration =
+        KmpProjectSettings(
+            platforms = platforms,
+            jvmTarget = jvmTarget,
+            kotlinVersion = kotlinVersion,
+            agpVersion = resolvedAgpVersion,
+        )
+    KmpSettingsStore.store(configuration)
+    registerKmpDefaults()
+}
+
+/**
+ * Buildscript classpath helper local to `:kmp` (do **not** import android's
+ * `buildScriptConfiguration` — that would create `:kmp` → `:android`).
+ */
+internal fun ScriptHandlerScope.kmpBuildscriptClasspath(classpathDeps: List<Any>) {
+    repositories {
+        google()
+        mavenCentral()
+    }
+    dependencies {
+        classpathDeps.forEach { dep ->
+            when (dep) {
+                is Provider<*> ->
+                    (dep.get() as? PluginDependency)?.let { plugin ->
+                        classpath("${plugin.pluginId}:${plugin.version.strictVersion}")
+                    }
+                        ?: throw IllegalArgumentException(
+                            "kmpProjectConfiguration extraPlugins: only PluginDependency providers are supported"
+                        )
+                else -> classpath(dep)
+            }
+        }
+    }
+}
+
+/** Optional repository block type alias for docs/symmetry (unused in v1 store). */
+typealias KmpRepositories = RepositoryHandler.() -> Unit

--- a/plugins/kmp/src/main/java/tools/forma/kmp/kmpTargetDsl.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/kmpTargetDsl.kt
@@ -1,0 +1,148 @@
+package tools.forma.kmp
+
+import org.gradle.api.Project
+import tools.forma.core.target.TargetType
+import tools.forma.deps.core.EmptyDependency
+import tools.forma.deps.core.FormaDependency
+import tools.forma.deps.core.applyTargetPlugins
+import tools.forma.deps.fleet.registerFormaLayout
+import tools.forma.kmp.feature.applyKmpDependencies
+import tools.forma.kmp.feature.applyKotlinMultiplatform
+import tools.forma.kmp.settings.KmpSettingsStore
+import tools.forma.kmp.target.KmpTargetRegistry
+import tools.forma.kmp.target.KmpTargetTypes
+import tools.forma.kmp.target.registerKmpDefaults
+import tools.forma.owners.NoOwner
+import tools.forma.owners.Owner
+import tools.forma.target.FormaTarget
+import tools.forma.validation.asValidator
+
+/**
+ * Shared multiplatform **library** (default workhorse). Type id `kmp.library`,
+ * name suffix `kmp-library`.
+ *
+ * Applies `org.jetbrains.kotlin.multiplatform` and project-global platforms from
+ * [kmpProjectConfiguration] (default jvm + android). Dependencies go to **commonMain**;
+ * [testDependencies] to **commonTest**.
+ *
+ * ## Layout / packageName
+ * [packageName] is recorded via [registerFormaLayout] with
+ * `requirePackageSourceDir = false` so Android/JVM `src/main` layout checks are not
+ * forced onto KMP modules. Prefer `src/commonMain/kotlin/…` (see docs/KMP-TARGETS.md §4.4).
+ * Full commonMain fleet check/generate lands in **F-109**.
+ *
+ * ## Platform-specific deps (open decision #2)
+ * Optional `androidDependencies` / `jvmDependencies` attrs are **deferred** — ship only when
+ * a consumer needs them. Until then, put shared deps in [dependencies]; platform-only code
+ * can use expect/actual with deps declared in a follow-up.
+ *
+ * @return [Unit] — no builder chains (F-081)
+ */
+fun Project.kmpLibrary(
+    packageName: String,
+    dependencies: FormaDependency = EmptyDependency,
+    testDependencies: FormaDependency = EmptyDependency,
+    owner: Owner = NoOwner,
+): Unit =
+    kmpTarget(
+        type = KmpTargetTypes.library,
+        packageName = packageName,
+        dependencies = dependencies,
+        testDependencies = testDependencies,
+        owner = owner,
+    )
+
+/**
+ * Shared public contracts (expect/actual-friendly). Type id `kmp.api`, suffix `kmp-api`.
+ */
+fun Project.kmpApi(
+    packageName: String,
+    dependencies: FormaDependency = EmptyDependency,
+    testDependencies: FormaDependency = EmptyDependency,
+    owner: Owner = NoOwner,
+): Unit =
+    kmpTarget(
+        type = KmpTargetTypes.api,
+        packageName = packageName,
+        dependencies = dependencies,
+        testDependencies = testDependencies,
+        owner = owner,
+    )
+
+/**
+ * Shared utilities / extensions. Type id `kmp.util`, suffix `kmp-util`.
+ */
+fun Project.kmpUtil(
+    packageName: String,
+    dependencies: FormaDependency = EmptyDependency,
+    testDependencies: FormaDependency = EmptyDependency,
+    owner: Owner = NoOwner,
+): Unit =
+    kmpTarget(
+        type = KmpTargetTypes.util,
+        packageName = packageName,
+        dependencies = dependencies,
+        testDependencies = testDependencies,
+        owner = owner,
+    )
+
+/**
+ * Shared test helpers (commonTest + platform tests). Type id `kmp.test-util`,
+ * suffix `kmp-test-util`.
+ */
+fun Project.kmpTestUtil(
+    packageName: String,
+    dependencies: FormaDependency = EmptyDependency,
+    testDependencies: FormaDependency = EmptyDependency,
+    owner: Owner = NoOwner,
+): Unit =
+    kmpTarget(
+        type = KmpTargetTypes.testUtil,
+        packageName = packageName,
+        dependencies = dependencies,
+        testDependencies = testDependencies,
+        owner = owner,
+    )
+
+/**
+ * Common flow for all KMP target DSLs (attributes only, Unit return).
+ *
+ * 1. [registerKmpDefaults]
+ * 2. self-validator via [KmpTargetRegistry]
+ * 3. layout metadata (commonMain-oriented; see F-109)
+ * 4. [applyKotlinMultiplatform]
+ * 5. [applyTargetPlugins]
+ * 6. [applyKmpDependencies] → commonMain / commonTest
+ */
+private fun Project.kmpTarget(
+    type: TargetType,
+    packageName: String,
+    dependencies: FormaDependency,
+    testDependencies: FormaDependency,
+    owner: Owner,
+) {
+    @Suppress("UNUSED_VARIABLE")
+    val unusedOwner = owner // reserved for F-owners parity; mandatoryOwners path is Android-only today
+
+    registerKmpDefaults()
+    // Ensure settings exist even when root skipped kmpProjectConfiguration (defaults).
+    if (!KmpSettingsStore.isSettingsStored) {
+        KmpSettingsStore.store(KmpSettingsStore.settingsOrDefaults())
+    }
+
+    KmpTargetRegistry.selfValidator(type).asValidator().validate(FormaTarget(this))
+
+    // Do not force src/main/kotlin — KMP uses commonMain. requirePackageSourceDir=false
+    // keeps formaLayoutCheck from failing greenfield KMP modules (F-109 extends fleet).
+    registerFormaLayout(packageName, requirePackageSourceDir = false)
+
+    applyKotlinMultiplatform(packageName = packageName)
+
+    applyTargetPlugins(type)
+
+    applyKmpDependencies(
+        validator = KmpTargetRegistry.validatorFor(type).asValidator(),
+        dependencies = dependencies,
+        testDependencies = testDependencies,
+    )
+}

--- a/plugins/kmp/src/main/java/tools/forma/kmp/settings/KmpProjectSettings.kt
+++ b/plugins/kmp/src/main/java/tools/forma/kmp/settings/KmpProjectSettings.kt
@@ -1,0 +1,76 @@
+package tools.forma.kmp.settings
+
+/**
+ * Project-global KMP platform policy (F-107 / docs/KMP-TARGETS.md §4.3, §7.1).
+ *
+ * Platforms are chosen **once** for the product — never re-listed per module.
+ * Defaults match the design happy path: **jvm + android** both on.
+ */
+data class KmpPlatforms(
+    val jvm: Boolean = true,
+    val android: Boolean = true,
+) {
+    init {
+        require(jvm || android) {
+            "KmpPlatforms: at least one of jvm/android must be true"
+        }
+    }
+}
+
+/**
+ * Stored by [tools.forma.kmp.kmpProjectConfiguration] (or defaults on first DSL use).
+ *
+ * @property platforms fleet-wide Kotlin targets (not call-site attrs)
+ * @property jvmTarget Kotlin/JVM bytecode target string (default `"11"`)
+ * @property kotlinVersion Kotlin Gradle plugin version on the buildscript classpath
+ * @property agpVersion AGP version for the Android KMP library plugin classpath when
+ *   [KmpPlatforms.android] is true; null means "align with existing Android toolchain
+ *   or fail at apply if android is requested without AGP"
+ */
+data class KmpProjectSettings(
+    val platforms: KmpPlatforms = KmpPlatforms(),
+    val jvmTarget: String = DEFAULT_KMP_JVM_TARGET,
+    val kotlinVersion: String? = null,
+    val agpVersion: String? = null,
+)
+
+/** Default JVM target for KMP jvm() — parity with pure JVM plugin (F-030). */
+const val DEFAULT_KMP_JVM_TARGET: String = "11"
+
+/**
+ * Process-wide store for [KmpProjectSettings] (parallel spirit to FormaSettingsStore,
+ * but owned by `:kmp` so the module never depends on `:android`).
+ */
+object KmpSettingsStore {
+    @Volatile
+    private var _settings: KmpProjectSettings? = null
+
+    val isSettingsStored: Boolean
+        get() = _settings != null
+
+    val settings: KmpProjectSettings
+        get() =
+            _settings
+                ?: error(
+                    "KmpProjectSettings not configured. Call kmpProjectConfiguration(...) " +
+                        "from the root buildscript, or use a KMP DSL entry (which registers defaults)."
+                )
+
+    fun store(configuration: KmpProjectSettings) {
+        _settings = configuration
+    }
+
+    /** Settings if [store] was called; otherwise null (does not throw). */
+    fun settingsOrNull(): KmpProjectSettings? = _settings
+
+    /**
+     * Settings if stored; otherwise [KmpProjectSettings] defaults
+     * (jvm+android, jvmTarget 11). Used by first-DSL-use default path.
+     */
+    fun settingsOrDefaults(): KmpProjectSettings = _settings ?: KmpProjectSettings()
+
+    /** Test-only reset. */
+    internal fun clear() {
+        _settings = null
+    }
+}

--- a/plugins/kmp/src/test/java/tools/forma/kmp/feature/KmpFeatureResolutionTest.kt
+++ b/plugins/kmp/src/test/java/tools/forma/kmp/feature/KmpFeatureResolutionTest.kt
@@ -1,0 +1,94 @@
+package tools.forma.kmp.feature
+
+import tools.forma.kmp.settings.KmpPlatforms
+import tools.forma.kmp.settings.KmpProjectSettings
+import tools.forma.kmp.settings.KmpSettingsStore
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertNotNull
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pure unit tests for applicator settings resolution / platform flags (F-107).
+ * No full AGP Project — Project apply paths stay out of jacoco happy-path gate.
+ */
+class KmpFeatureResolutionTest {
+
+    @BeforeTest
+    @AfterTest
+    fun resetStore() {
+        KmpSettingsStore.clear()
+    }
+
+    @Test
+    fun `resolveSettings uses defaults when store empty`() {
+        val s = KmpFeatureResolution.resolveSettings(store = null)
+        assertTrue(s.platforms.jvm)
+        assertTrue(s.platforms.android)
+        assertEquals("11", KmpFeatureResolution.jvmTarget(s))
+    }
+
+    @Test
+    fun `resolveSettings reads store when present`() {
+        val custom =
+            KmpProjectSettings(
+                platforms = KmpPlatforms(jvm = true, android = false),
+                jvmTarget = "17",
+            )
+        KmpSettingsStore.store(custom)
+        val s = KmpFeatureResolution.resolveSettings()
+        assertEquals(custom, s)
+        assertEquals(false, KmpFeatureResolution.platforms(s).android)
+        assertEquals("17", KmpFeatureResolution.jvmTarget(s))
+    }
+
+    @Test
+    fun `androidApplyErrorOrNull null when android platform off`() {
+        val s =
+            KmpProjectSettings(
+                platforms = KmpPlatforms(jvm = true, android = false),
+            )
+        assertNull(
+            KmpFeatureResolution.androidApplyErrorOrNull(
+                settings = s,
+                androidSettingsStored = false,
+            )
+        )
+    }
+
+    @Test
+    fun `androidApplyErrorOrNull when android on without Android settings`() {
+        val s = KmpProjectSettings() // android default true
+        val err =
+            KmpFeatureResolution.androidApplyErrorOrNull(
+                settings = s,
+                androidSettingsStored = false,
+            )
+        assertNotNull(err)
+        assertTrue(err.contains("androidProjectConfiguration"))
+        assertTrue(err.contains("android = false"))
+    }
+
+    @Test
+    fun `androidApplyErrorOrNull null when android on and Android settings present`() {
+        val s = KmpProjectSettings()
+        assertNull(
+            KmpFeatureResolution.androidApplyErrorOrNull(
+                settings = s,
+                androidSettingsStored = true,
+            )
+        )
+    }
+
+    @Test
+    fun `plugin ids match AGP 9_3 spike`() {
+        assertEquals("org.jetbrains.kotlin.multiplatform", KmpPluginIds.KOTLIN_MULTIPLATFORM)
+        assertEquals(
+            "com.android.kotlin.multiplatform.library",
+            KmpPluginIds.ANDROID_KMP_LIBRARY,
+        )
+    }
+}

--- a/plugins/kmp/src/test/java/tools/forma/kmp/settings/KmpProjectSettingsTest.kt
+++ b/plugins/kmp/src/test/java/tools/forma/kmp/settings/KmpProjectSettingsTest.kt
@@ -1,0 +1,73 @@
+package tools.forma.kmp.settings
+
+import kotlin.test.AfterTest
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertEquals
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertNull
+import kotlin.test.assertTrue
+
+/**
+ * Pure unit tests for KMP settings store and platform defaults (F-107).
+ */
+class KmpProjectSettingsTest {
+
+    @BeforeTest
+    @AfterTest
+    fun resetStore() {
+        KmpSettingsStore.clear()
+    }
+
+    @Test
+    fun `defaults enable jvm and android with jvmTarget 11`() {
+        val s = KmpProjectSettings()
+        assertTrue(s.platforms.jvm)
+        assertTrue(s.platforms.android)
+        assertEquals("11", s.jvmTarget)
+        assertEquals(DEFAULT_KMP_JVM_TARGET, s.jvmTarget)
+        assertNull(s.kotlinVersion)
+        assertNull(s.agpVersion)
+    }
+
+    @Test
+    fun `platforms require at least one of jvm or android`() {
+        assertFailsWith<IllegalArgumentException> {
+            KmpPlatforms(jvm = false, android = false)
+        }
+        // jvm-only and android-only are valid
+        KmpPlatforms(jvm = true, android = false)
+        KmpPlatforms(jvm = false, android = true)
+    }
+
+    @Test
+    fun `store and settingsOrDefaults`() {
+        assertFalse(KmpSettingsStore.isSettingsStored)
+        assertNull(KmpSettingsStore.settingsOrNull())
+        val defaults = KmpSettingsStore.settingsOrDefaults()
+        assertTrue(defaults.platforms.jvm)
+        assertTrue(defaults.platforms.android)
+
+        val custom =
+            KmpProjectSettings(
+                platforms = KmpPlatforms(jvm = true, android = false),
+                jvmTarget = "17",
+                kotlinVersion = "2.3.21",
+                agpVersion = null,
+            )
+        KmpSettingsStore.store(custom)
+        assertTrue(KmpSettingsStore.isSettingsStored)
+        assertEquals(custom, KmpSettingsStore.settings)
+        assertEquals(custom, KmpSettingsStore.settingsOrNull())
+        assertEquals("17", KmpSettingsStore.settingsOrDefaults().jvmTarget)
+        assertFalse(KmpSettingsStore.settings.platforms.android)
+    }
+
+    @Test
+    fun `settings throws when never stored`() {
+        assertFailsWith<IllegalStateException> {
+            KmpSettingsStore.settings
+        }
+    }
+}


### PR DESCRIPTION
## Summary

Implements **F-107** (P11 KMP): type-owned Kotlin Multiplatform apply path and public DSL on `tools.forma.kmp`.

- **`kmpProjectConfiguration`** (`ScriptHandlerScope`) — registers KMP matrix defaults, stores `KmpProjectSettings` (jvm+android default on, `jvmTarget = "11"`), puts Kotlin MPP (+ AGP when android) on **buildscript classpath only**
- **Feature applicator** — `org.jetbrains.kotlin.multiplatform` + **`com.android.kotlin.multiplatform.library`** (AGP 9.3 spike; no classic `com.android.library` fallback); jvm target; fail-fast if android platform without `androidProjectConfiguration`
- **DSL** — `kmpLibrary` / `kmpApi` / `kmpUtil` / `kmpTestUtil` (Unit); deps → commonMain / commonTest via Kotlin source-set API + same project-dep validators
- **Cycle rule** — `:kmp` ↛ `:android` (`compileOnly` AGP + string plugin ids / reflection)
- **Docs** — `docs/KMP-TARGETS.md` §4.3 spike result; TICKETS/PROGRESS/ARCHITECTURE

Out of scope (next tickets): F-108 consumer edges, F-109 example, F-110 user docs; platform-specific dep attrs deferred.

## Verify (host)

```bash
source scripts/env-mac.sh
cd plugins
./gradlew :kmp:test   # 15 tests
./gradlew test jacocoHappyPathCoverageVerification
```

Both **BUILD SUCCESSFUL**.

## Test plan

- [x] `:kmp:test` (registry 5 + settings 4 + resolution 6)
- [x] Full plugins `test` + jacoco happy-path gate
- [ ] CI on this PR
- [ ] F-109 progressive example (smoke apply in real module)