### PR TITLE
F-108: Android/JVM consumer matrix edges for kmp.*

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -158,7 +158,7 @@ composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 | F-105 | done | Design KMP targets + matrix + plugin shape | `docs/KMP-TARGETS.md` — types `kmp-api`/`kmp-library`/`kmp-util`/`kmp-test-util`; `kmpProjectConfiguration`; rejected free-form `kotlin { targets }`; VISION/ARCHITECTURE/README pointers |
 | F-106 | done | `:kmp` plugin skeleton + `KmpTargetRegistry` matrix tests | Module `plugins/kmp`, plugin id `tools.forma.kmp`, types + `registerKmpDefaults`, 5 unit tests; jacoco happy-path includes `kmp/target/**`; no public DSL until F-107 |
 | F-107 | done | Apply kotlin-multiplatform + `kmpLibrary` DSL | `kmpProjectConfiguration` + feature applicator (`com.android.kotlin.multiplatform.library` + jvm); `kmpLibrary`/`kmpApi`/`kmpUtil`/`kmpTestUtil`; commonMain deps; unit tests; plugins jacoco green |
-| F-108 | todo | Android/JVM consumer matrix edges → kmp.* | Extend `AndroidTargetRegistry` + `JvmTargetRegistry`; update `DEPENDENCY-MATRIX.md` from code; avoid `:kmp`→`:android` cycle |
+| F-108 | done | Android/JVM consumer matrix edges → kmp.* | Extend `AndroidTargetRegistry` + `JvmTargetRegistry`; update `DEPENDENCY-MATRIX.md` from code; avoid `:kmp`→`:android` cycle |
 | F-109 | todo | Progressive example `examples/kmp/01-shared-library` | Shared `kmp-library` + JVM (and optional Android) consumer; green documented Gradle tasks |
 | F-110 | todo | KMP user docs + agent skill + curriculum | `KMP-GETTING-STARTED.md`, `examples/agent-skills/forma-kmp-targets.md`, PROGRESSIVE-EXAMPLES ladder, README |
 

--- a/docs/DEPENDENCY-MATRIX.md
+++ b/docs/DEPENDENCY-MATRIX.md
@@ -8,7 +8,9 @@ Source of truth for **F-010**. Every rule below is taken from the live
 When validators change, update **this file first**, then the README summary
 matrix. Do not invent rules from aspirational docs.
 
-Last verified: **2026-07-17** against `v2` + F-063 hard-remove of `androidLibrary`.
+Last verified: **2026-07-25** against `v2` + F-108 Android/JVM → KMP consumer edges
+(registries in `AndroidTargetRegistry` / `JvmTargetRegistry`; KMP internal matrix in
+[`KMP-TARGETS.md`](KMP-TARGETS.md) §6.1).
 
 ---
 
@@ -120,20 +122,20 @@ these suffixes (or are unrestricted if `EmptyValidator`).
 
 | Consumer DSL | Source file | Project-dep validator | Allowed dependency suffixes |
 |--------------|-------------|------------------------|-----------------------------|
-| `api` | `api.kt` | `validator(api, library)` | `api`, `library` |
-| `impl` | `impl.kt` | `validator(api, android-util, test-util, util, library, ui-library, res, viewbinding, widget, compose-widget)` | `api`, `android-util`, `test-util`, `util`, `library`, `ui-library`, `res`, `viewbinding`, `widget`, `compose-widget` |
+| `api` | `api.kt` | registry: api, library, **kmp-api** | `api`, `library`, `kmp-api` |
+| `impl` | `impl.kt` | registry + **kmp-api, kmp-library, kmp-util** | `api`, `android-util`, `test-util`, `util`, `library`, `ui-library`, `res`, `viewbinding`, `widget`, `compose-widget`, `kmp-api`, `kmp-library`, `kmp-util` |
 | `library` (JVM) | `library.kt` | `validator(util, test-util)` | `util`, `test-util` |
 | `uiLibrary` | `uiLibrary.kt` | `validator(widget, compose-widget, util, android-util, res)` | `widget`, `compose-widget`, `util`, `android-util`, `res` |
 | `util` | `util.kt` | `validator(util, library)` | `util`, `library` |
-| `androidUtil` | `androidUtil.kt` | `validator(android-util, test-util, res, library)` | `android-util`, `test-util`, `res`, `library` |
+| `androidUtil` | `androidUtil.kt` | registry + **kmp-library, kmp-util** | `android-util`, `test-util`, `res`, `library`, `kmp-library`, `kmp-util` |
 | `testUtil` | `testUtil.kt` | `validator(test-util, util)` | `test-util`, `util` |
 | `androidTestUtil` | `androidTestUtil.kt` | `validator(android-test-util, test-util)` | `android-test-util`, `test-util` |
 | `androidRes` | `androidRes.kt` | `validator(res, widget, compose-widget)` | `res`, `widget`, `compose-widget` |
 | `widget` | `widget.kt` | `validator(ui-library, widget, compose-widget, util, android-util, res)` | `ui-library`, `widget`, `compose-widget`, `util`, `android-util`, `res` |
 | `composeWidget` | `composeWidget.kt` | `validator(ui-library, compose-widget, widget, util, android-util, res)` | `ui-library`, `compose-widget`, `widget`, `util`, `android-util`, `res` |
 | `viewBinding` | `viewBinding.kt` | `validator(api, widget, compose-widget, res, library, android-util, ui-library)` | `api`, `widget`, `compose-widget`, `res`, `library`, `android-util`, `ui-library` |
-| `androidApp` | `androidApp.kt` | `validator(api, impl, library, util, android-util, test-util, res, viewbinding, widget, compose-widget, ui-library)` | `api`, `impl`, `library`, `util`, `android-util`, `test-util`, `res`, `viewbinding`, `widget`, `compose-widget`, `ui-library` |
-| `androidBinary` | `androidBinary.kt` | `validator(app, api, impl, library, util, android-util, test-util, res, viewbinding, widget, compose-widget, ui-library)` | `app`, `api`, `impl`, `library`, `util`, `android-util`, `test-util`, `res`, `viewbinding`, `widget`, `compose-widget`, `ui-library` |
+| `androidApp` | `androidApp.kt` | registry + **kmp-api, kmp-library, kmp-util** | `api`, `impl`, `library`, `util`, `android-util`, `test-util`, `res`, `viewbinding`, `widget`, `compose-widget`, `ui-library`, `kmp-api`, `kmp-library`, `kmp-util` |
+| `androidBinary` | `androidBinary.kt` | registry + **kmp-api, kmp-library, kmp-util** | `app`, `api`, `impl`, `library`, `util`, `android-util`, `test-util`, `res`, `viewbinding`, `widget`, `compose-widget`, `ui-library`, `kmp-api`, `kmp-library`, `kmp-util` |
 | `androidNative` | `androidNative.kt` | *(no `applyDependencies`)* | *no project-dep validation* |
 
 ### Explicit non-edges (important product rules)
@@ -155,6 +157,12 @@ These follow from the table (not from separate deny-lists):
   may depend on `widget` / `compose-widget`, and `widget` / `compose-widget`
   may depend on `ui-library` and on each other so View + Compose can coexist
   (F-013 / GH #96).
+- **No KMP → Android / JVM** — `KmpTargetRegistry` does not list android/jvm types
+  (F-105/F-108 cycle rule). Direction is Android/JVM → KMP only.
+- **No kmp edges on UI leaves** — widget / composeWidget / res / viewBinding /
+  uiLibrary / androidTestUtil do not gain kmp.* (design §6.2).
+- **No `kmp-test-util` on Android/JVM consumers in v1** — reserved for KMP test
+  helpers; may land later with an explicit ticket.
 
 ### Compose flags (not project-dep rules)
 
@@ -220,6 +228,58 @@ allowed list (e.g. `api`→`api` **Y**, `impl`→`impl` **—**, `widget`→`wid
 
 ---
 
+## Android / JVM → KMP consumer edges (F-108)
+
+Code truth: `AndroidTargetRegistry` + `JvmTargetRegistry` import
+`KmpTargetTypes` (`implementation(project(":kmp"))`). Internal KMP→KMP matrix:
+[`KMP-TARGETS.md`](KMP-TARGETS.md) §6.1 (`KmpTargetRegistry`).
+
+| Consumer | May depend on KMP (type ids) |
+|----------|------------------------------|
+| `android.api` | `kmp.api` only |
+| `android.impl` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `android.android-util` | `kmp.library`, `kmp.util` |
+| `android.app` / `android.binary` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `jvm.api` | `kmp.api` |
+| `jvm.impl` / `jvm.binary` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `jvm.library` / `jvm.util` | `kmp.library`, `kmp.util` |
+
+**Not listed (no kmp edges):** Android UI leaves + `androidTestUtil` / `testUtil`;
+JVM `test-util`. **`kmp-test-util`** is not on any Android/JVM consumer in v1.
+
+**Plugin graph:** `:android` and `:jvm` may depend on `:kmp`. `:kmp` must **not**
+`implementation(project(":android"))` or `:jvm` (cycle rule).
+
+**Suffix overlap (known limitation):** `SuffixNameMatcher` matches
+`project.endsWith("-$suffix")`. Names like `shared-kmp-library` also end with
+`-library`, so a consumer that already allows `library` accepts them via the
+unprefixed suffix even when the **graph** denies `kmp.library` (e.g. `api` →
+`kmp.library` is `isAllowed=false`, but validator may still accept the name via
+`library`). Authoritative design checks use restriction-graph type pairs; a
+longest-suffix matcher is out of scope for F-108.
+
+Compact KMP columns (Android consumers that gain edges):
+
+| Consumer ↓ \ KMP → | kmp-api | kmp-library | kmp-util | kmp-test-util |
+|--------------------|---------|-------------|----------|---------------|
+| **api** | Y | — | — | — |
+| **impl** | Y | Y | Y | — |
+| **androidUtil** | — | Y | Y | — |
+| **androidApp** | Y | Y | Y | — |
+| **androidBinary** | Y | Y | Y | — |
+| other Android rows | — | — | — | — |
+
+| Consumer ↓ \ KMP → | kmp-api | kmp-library | kmp-util | kmp-test-util |
+|--------------------|---------|-------------|----------|---------------|
+| **jvm.api** | Y | — | — | — |
+| **jvm.impl** | Y | Y | Y | — |
+| **jvm.binary** | Y | Y | Y | — |
+| **jvm.library** | — | Y | Y | — |
+| **jvm.util** | — | Y | Y | — |
+| **jvm.test-util** | — | — | — | — |
+
+---
+
 ## README matrix vs code (divergences)
 
 The historical README table used columns as *consumers* and rows as
@@ -265,4 +325,5 @@ Tightening unrestricted entry targets landed in **F-011**.
 4. Note the change in `docs/PROGRESS.md` / ticket notes when user-facing.
 
 Related tickets: **F-013** (Compose), **F-012** (deps catalog UX), **F-020**
-(forma-core type registry / shared `library` suffix).
+(forma-core type registry / shared `library` suffix), **F-108** (Android/JVM →
+KMP consumer edges).

--- a/docs/KMP-TARGETS.md
+++ b/docs/KMP-TARGETS.md
@@ -270,7 +270,9 @@ shallow; composition of **features** still happens at Android/JVM roots.
 
 ### 6.2 Android / JVM → KMP (consumer edges)
 
-Extend existing registries (F-108):
+**Implemented (F-108):** edges live in `AndroidTargetRegistry` /
+`JvmTargetRegistry` via `KmpTargetTypes`. Code-truth tables:
+[`DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md) § Android/JVM → KMP.
 
 | Consumer | May depend on KMP |
 |----------|-------------------|
@@ -282,7 +284,7 @@ Extend existing registries (F-108):
 | `jvm.impl` / `jvm.binary` | `kmp.api`, `kmp.library`, `kmp.util` |
 | `jvm.library` / `jvm.util` | `kmp.library`, `kmp.util` (optional; prefer depending upward only if needed) |
 
-Update [`DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md) **when code lands** (code truth rule).
+Plugin graph: `:android` / `:jvm` → `:kmp` allowed; reverse **forbidden** (no cycle).
 
 ### 6.3 How Gradle edges resolve
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest entries first.
 
+## 2026-07-25 — F-108: Android/JVM consumer matrix edges → kmp.*
+
+- **Ticket:** F-108 → `done` (next F-109 progressive KMP example)
+- **Branch:** `forma/F-108-kmp-consumer-matrix` (from `origin/v2` @ F-107)
+- **Code:**
+  - `plugins/android` + `plugins/jvm`: `implementation(project(":kmp"))` (import `KmpTargetTypes`); publishPlugins chains `:kmp:publishPlugins`
+  - **No** `:kmp` → `:android` / `:jvm` (cycle rule unchanged)
+  - `AndroidTargetRegistry`: api→kmp.api; impl/app/binary→kmp.api+library+util; androidUtil→kmp.library+util; UI leaves unchanged
+  - `JvmTargetRegistry`: api→kmp.api; impl/binary→kmp.api+library+util; library/util→kmp.library+util; testUtil no kmp
+  - Unit tests: `AndroidTargetRegistryKmpEdgesTest`, `JvmTargetRegistryKmpEdgesTest` (graph + validator)
+  - Jacoco: add `kmp` to `coverageReportModules` so F-106/F-107 happy-path includes actually contribute exec data
+- **Suffix overlap (known limitation):** `*-kmp-library` ends with `-library`, so SuffixNameMatcher may accept kmp-named projects via unprefixed library/api/util allow-lists even when graph denies the kmp type pair (e.g. api↛kmp.library). Design truth = restrictionGraph `isAllowed`; longest-suffix matcher out of scope.
+- **Docs:** `DEPENDENCY-MATRIX.md` § Android/JVM → KMP; `KMP-TARGETS.md` §6.2 marked implemented; TICKETS F-108 done
+- **Verify (real host, `source scripts/env-mac.sh`):**
+  - `plugins/`: `./gradlew :android:test :jvm:test :kmp:test` → **BUILD SUCCESSFUL** (53s)
+  - `plugins/`: `./gradlew test jacocoHappyPathCoverageVerification` → **BUILD SUCCESSFUL** (22s)
+  - `:kmp` compileClasspath has **no** `project :android` / `project :jvm` (cycle rule OK)
+- **Skills/modes:** Grok Build `--mode full` (design/plan + implement); Hermes finish path after CLI timeout on jacoco
+- **Next step:** F-109 — progressive example `examples/kmp/01-shared-library`
+
 ## 2026-07-25 — F-107: kmpLibrary DSL + multiplatform apply + kmpProjectConfiguration
 
 - **Ticket:** F-107 → `done` (next F-108 consumer matrix edges)

--- a/plugins/android/build.gradle.kts
+++ b/plugins/android/build.gradle.kts
@@ -27,6 +27,8 @@ dependencies {
     implementation(project(":deps"))
     // F-021: core restriction + target types (pure engine); Android owns concrete type instances + matrix
     implementation(project(":core"))
+    // F-108: consumer matrix edges → kmp.* (import KmpTargetTypes; :kmp must NOT depend on :android)
+    implementation(project(":kmp"))
 
     // F-097: pure model tests (FormaSigningConfig / buildTypeSigning resolver)
     testImplementation(kotlin("test"))
@@ -43,5 +45,6 @@ tasks.named<Task>("publishPlugins") {
         ":owners:publishPlugins",
         ":config:publishPlugins",
         ":deps:publishPlugins",
+        ":kmp:publishPlugins",
     )
 }

--- a/plugins/android/src/main/java/tools/forma/android/target/AndroidTargetRegistry.kt
+++ b/plugins/android/src/main/java/tools/forma/android/target/AndroidTargetRegistry.kt
@@ -13,6 +13,7 @@ import tools.forma.deps.core.TargetPluginSpec
 import tools.forma.deps.core.deriveTargetType as deriveTargetTypeWithCoreRegistry
 import tools.forma.deps.core.registerTargetPlugin as registerTargetPluginGlobal
 import tools.forma.deps.core.targetPlugin as targetPluginFactory
+import tools.forma.kmp.target.KmpTargetTypes
 
 /**
  * Singleton registry for Android platform target types.
@@ -21,6 +22,13 @@ import tools.forma.deps.core.targetPlugin as targetPluginFactory
  * DSL entrypoints obtain self + dependency validators from here (no more hand-written allow-lists).
  * Note: the historical `androidLibrary` target (android.library) was hard-removed in F-063.
  * Only JVM `library` (jvm.library) now uses the `library` suffix.
+ *
+ * F-108 KMP consumer edges (docs/KMP-TARGETS.md §6.2) — Android → kmp only; never kmp → android:
+ * - api            → kmp.api
+ * - impl           → kmp.api, kmp.library, kmp.util
+ * - androidUtil    → kmp.library, kmp.util
+ * - app / binary   → kmp.api, kmp.library, kmp.util
+ * UI leaves (widget/composeWidget/res/viewBinding/uiLibrary/androidTestUtil) have **no** kmp edges.
  */
 object AndroidTargetRegistry : TargetRegistry by DefaultTargetRegistry()
 
@@ -34,26 +42,28 @@ object AndroidTargetRegistry : TargetRegistry by DefaultTargetRegistry()
  */
 fun registerAndroidDefaults(registry: TargetRegistry = AndroidTargetRegistry) {
     val t = AndroidTargetTypes
+    val k = KmpTargetTypes
     val noRes = listOf(NoResourcesUnderMain)
     val onlyRes = listOf(OnlyResourcesUnderMain)
     val onlyLayouts = listOf(OnlyLayoutResources)
 
-    // api: api + jvm library (JVM contract layer)
+    // api: api + jvm library + kmp.api contracts (no kmp.library — keep api thin)
     registry.register(
         TargetRegistration(
             type = t.api,
-            allowedDependencies = setOf(t.api, t.jvmLibrary),
+            allowedDependencies = setOf(t.api, t.jvmLibrary, k.api),
             contentRules = noRes
         )
     )
 
-    // impl: api + utils + libraries + ui blocks; **no impl**
+    // impl: api + utils + libraries + ui blocks + shared KMP; **no impl**
     registry.register(
         TargetRegistration(
             type = t.impl,
             allowedDependencies = setOf(
                 t.api, t.androidUtil, t.testUtil, t.util, t.jvmLibrary,
-                t.uiLibrary, t.res, t.viewBinding, t.widget, t.composeWidget
+                t.uiLibrary, t.res, t.viewBinding, t.widget, t.composeWidget,
+                k.api, k.library, k.util,
             )
         )
     )
@@ -66,7 +76,7 @@ fun registerAndroidDefaults(registry: TargetRegistry = AndroidTargetRegistry) {
         )
     )
 
-    // uiLibrary
+    // uiLibrary — no KMP edges (design §6.2 UI leaves)
     registry.register(
         TargetRegistration(
             type = t.uiLibrary,
@@ -83,11 +93,14 @@ fun registerAndroidDefaults(registry: TargetRegistry = AndroidTargetRegistry) {
         )
     )
 
-    // androidUtil — may wrap pure JVM libraries; still no res content
+    // androidUtil — may wrap pure JVM libraries + shared KMP library/util; still no res content
     registry.register(
         TargetRegistration(
             type = t.androidUtil,
-            allowedDependencies = setOf(t.androidUtil, t.testUtil, t.res, t.jvmLibrary),
+            allowedDependencies = setOf(
+                t.androidUtil, t.testUtil, t.res, t.jvmLibrary,
+                k.library, k.util,
+            ),
             contentRules = noRes
         )
     )
@@ -101,7 +114,7 @@ fun registerAndroidDefaults(registry: TargetRegistry = AndroidTargetRegistry) {
         )
     )
 
-    // androidTestUtil
+    // androidTestUtil — no KMP edges (v1 §6.2)
     registry.register(
         TargetRegistration(
             type = t.androidTestUtil,
@@ -145,25 +158,27 @@ fun registerAndroidDefaults(registry: TargetRegistry = AndroidTargetRegistry) {
         )
     )
 
-    // androidApp (composition root)
+    // androidApp (composition root) + shared KMP stack
     registry.register(
         TargetRegistration(
             type = t.app,
             allowedDependencies = setOf(
                 t.api, t.impl, t.jvmLibrary, t.util, t.androidUtil, t.testUtil, t.res,
-                t.viewBinding, t.widget, t.composeWidget, t.uiLibrary
+                t.viewBinding, t.widget, t.composeWidget, t.uiLibrary,
+                k.api, k.library, k.util,
             ),
             contentRules = noRes
         )
     )
 
-    // androidBinary (composition root)
+    // androidBinary (composition root) + shared KMP stack
     registry.register(
         TargetRegistration(
             type = t.binary,
             allowedDependencies = setOf(
                 t.app, t.api, t.impl, t.jvmLibrary, t.util, t.androidUtil, t.testUtil, t.res,
-                t.viewBinding, t.widget, t.composeWidget, t.uiLibrary
+                t.viewBinding, t.widget, t.composeWidget, t.uiLibrary,
+                k.api, k.library, k.util,
             ),
             contentRules = noRes
         )

--- a/plugins/android/src/test/kotlin/tools/forma/android/target/AndroidTargetRegistryKmpEdgesTest.kt
+++ b/plugins/android/src/test/kotlin/tools/forma/android/target/AndroidTargetRegistryKmpEdgesTest.kt
@@ -1,0 +1,122 @@
+package tools.forma.android.target
+
+import tools.forma.core.target.TargetRef
+import tools.forma.core.validation.FormaValidationException
+import tools.forma.kmp.target.KmpTargetTypes
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * F-108: Android consumers → kmp.* restriction edges (docs/KMP-TARGETS.md §6.2).
+ *
+ * Graph assertions use [TargetType] pairs (design matrix truth).
+ * Suffix validators also exercise kmp-named projects; note that SuffixNameMatcher
+ * treats `*-kmp-library` as ending with `-library`, so consumers that already allow
+ * jvm.library will accept those names via overlap even without kmp.library in the set.
+ * Graph-level [isAllowed] remains the authoritative design check for type pairs.
+ */
+class AndroidTargetRegistryKmpEdgesTest {
+
+    private data class TestRef(override val name: String) : TargetRef
+
+    @BeforeTest
+    fun setup() {
+        registerAndroidDefaults()
+    }
+
+    @Test
+    fun `restriction graph encodes android to kmp consumer matrix`() {
+        val t = AndroidTargetTypes
+        val k = KmpTargetTypes
+        val g = AndroidTargetRegistry.restrictionGraph()
+
+        // api → kmp.api only
+        assertTrue(g.isAllowed(t.api, k.api))
+        assertFalse(g.isAllowed(t.api, k.library))
+        assertFalse(g.isAllowed(t.api, k.util))
+        assertFalse(g.isAllowed(t.api, k.testUtil))
+
+        // impl → kmp.api, kmp.library, kmp.util (not kmp-test-util)
+        assertTrue(g.isAllowed(t.impl, k.api))
+        assertTrue(g.isAllowed(t.impl, k.library))
+        assertTrue(g.isAllowed(t.impl, k.util))
+        assertFalse(g.isAllowed(t.impl, k.testUtil))
+
+        // androidUtil → kmp.library, kmp.util (not kmp.api)
+        assertFalse(g.isAllowed(t.androidUtil, k.api))
+        assertTrue(g.isAllowed(t.androidUtil, k.library))
+        assertTrue(g.isAllowed(t.androidUtil, k.util))
+        assertFalse(g.isAllowed(t.androidUtil, k.testUtil))
+
+        // composition roots
+        for (root in listOf(t.app, t.binary)) {
+            assertTrue(g.isAllowed(root, k.api))
+            assertTrue(g.isAllowed(root, k.library))
+            assertTrue(g.isAllowed(root, k.util))
+            assertFalse(g.isAllowed(root, k.testUtil))
+        }
+
+        // UI / leaf types: no kmp edges (design §6.2)
+        for (leaf in listOf(
+            t.widget, t.composeWidget, t.res, t.viewBinding, t.uiLibrary, t.androidTestUtil,
+        )) {
+            assertFalse(g.isAllowed(leaf, k.api))
+            assertFalse(g.isAllowed(leaf, k.library))
+            assertFalse(g.isAllowed(leaf, k.util))
+            assertFalse(g.isAllowed(leaf, k.testUtil))
+        }
+
+        // Existing Android edges stay intact (spot-check)
+        assertTrue(g.isAllowed(t.api, t.api))
+        assertTrue(g.isAllowed(t.api, t.jvmLibrary))
+        assertFalse(g.isAllowed(t.impl, t.impl))
+        assertTrue(g.isAllowed(t.impl, t.api))
+    }
+
+    @Test
+    fun `validators accept kmp project names for allowed consumers`() {
+        val t = AndroidTargetTypes
+
+        val apiV = AndroidTargetRegistry.validatorFor(t.api)
+        apiV.validate(TestRef("core-kmp-api"))
+        // shared-kmp-library also ends with -library (jvm.library suffix overlap) — accepted
+        // via existing library allow-list; graph still denies kmp.library for api (see above).
+        apiV.validate(TestRef("shared-kmp-library"))
+
+        val implV = AndroidTargetRegistry.validatorFor(t.impl)
+        implV.validate(TestRef("core-kmp-api"))
+        implV.validate(TestRef("shared-kmp-library"))
+        implV.validate(TestRef("net-kmp-util"))
+
+        val utilV = AndroidTargetRegistry.validatorFor(t.androidUtil)
+        utilV.validate(TestRef("shared-kmp-library"))
+        utilV.validate(TestRef("net-kmp-util"))
+
+        val appV = AndroidTargetRegistry.validatorFor(t.app)
+        appV.validate(TestRef("core-kmp-api"))
+        appV.validate(TestRef("shared-kmp-library"))
+        appV.validate(TestRef("net-kmp-util"))
+    }
+
+    @Test
+    fun `validators reject plain android impl for api and kmp-test-util when not allowed`() {
+        val t = AndroidTargetTypes
+
+        val apiV = AndroidTargetRegistry.validatorFor(t.api)
+        assertFailsWith<FormaValidationException> { apiV.validate(TestRef("feature-impl")) }
+
+        // kmp-test-util is not on any §6.2 Android consumer allow-list.
+        // Suffix is distinct (does not end with -test-util alone? actually ends with -test-util).
+        // android.impl allows test-util → overlap may accept *-kmp-test-util as test-util.
+        // Graph-level deny is authoritative; suffix engine limitation documented in PROGRESS.
+        val implV = AndroidTargetRegistry.validatorFor(t.impl)
+        implV.validate(TestRef("shared-kmp-test-util")) // overlap with test-util suffix
+
+        // widget still rejects non-UI deps that are not in its allow-list when suffix is unique
+        val widgetV = AndroidTargetRegistry.validatorFor(t.widget)
+        assertFailsWith<FormaValidationException> { widgetV.validate(TestRef("feature-impl")) }
+    }
+}

--- a/plugins/buildSrc/src/main/kotlin/formaCoverage.kt
+++ b/plugins/buildSrc/src/main/kotlin/formaCoverage.kt
@@ -19,7 +19,7 @@ import java.util.concurrent.Callable
  * Modules that run unit tests and contribute to Jacoco reports.
  * Platform facades without unit suites (android/target/…) are sample-build covered.
  */
-internal val coverageReportModules = setOf("core", "config", "deps", "jvm")
+internal val coverageReportModules = setOf("core", "config", "deps", "jvm", "kmp")
 
 /**
  * Minimum LINE covered ratio for the **happy-path** class set (see

--- a/plugins/jvm/build.gradle.kts
+++ b/plugins/jvm/build.gradle.kts
@@ -25,6 +25,8 @@ dependencies {
     implementation(project(":validation"))
     implementation(project(":target"))
     implementation(project(":owners"))
+    // F-108: consumer matrix edges → kmp.* (import KmpTargetTypes; :kmp must NOT depend on :jvm)
+    implementation(project(":kmp"))
 
     testImplementation(kotlin("test"))
 }
@@ -34,6 +36,6 @@ tasks.test {
 }
 
 tasks.named<Task>("publishPlugins") {
-    // If/when wiring a root publish that chains jvm too, list deps here.
-    // For F-030 slice, standalone :jvm:publishPlugins works for validation.
+    // Publish KMP first when chaining jvm (F-108 embeds KmpTargetTypes).
+    dependsOn(":kmp:publishPlugins")
 }

--- a/plugins/jvm/src/main/java/tools/forma/jvm/target/JvmTargetRegistry.kt
+++ b/plugins/jvm/src/main/java/tools/forma/jvm/target/JvmTargetRegistry.kt
@@ -3,6 +3,7 @@ package tools.forma.jvm.target
 import tools.forma.core.target.DefaultTargetRegistry
 import tools.forma.core.target.TargetRegistration
 import tools.forma.core.target.TargetRegistry
+import tools.forma.kmp.target.KmpTargetTypes
 
 /**
  * Singleton registry for pure JVM target types (F-030).
@@ -15,48 +16,54 @@ object JvmTargetRegistry : TargetRegistry by DefaultTargetRegistry()
  * Register JVM target types + restriction matrix.
  *
  * Matrix (Dagger-friendly, pure JVM, no Android types):
- * - api      → api, library
- * - impl     → api, library, util, test-util   (NO impl — composition only at binary/app roots later)
- * - library  → util, test-util
- * - util     → util, library
- * - testUtil → test-util, util   (library allowed for test helpers that need prod contracts)
- * - binary   → api, impl, library, util, test-util   (composition root for wiring multiple impls)
+ * - api      → api, library, kmp.api
+ * - impl     → api, library, util, test-util, kmp.api, kmp.library, kmp.util
+ *              (NO impl — composition only at binary/app roots)
+ * - library  → util, test-util, kmp.library, kmp.util
+ * - util     → util, library, kmp.library, kmp.util
+ * - testUtil → test-util, util, library   (no kmp-test-util in v1 §6.2)
+ * - binary   → api, impl, library, util, test-util, kmp.api, kmp.library, kmp.util
  *
+ * F-108 KMP consumer edges (docs/KMP-TARGETS.md §6.2) — JVM → kmp only; never kmp → jvm.
  * No ContentRules attached for pure JVM (no Android resources concept).
  * Safe to call multiple times (re-register replaces).
  */
 fun registerJvmDefaults(registry: TargetRegistry = JvmTargetRegistry) {
     val t = JvmTargetTypes
+    val k = KmpTargetTypes
 
-    // api: contracts only — api + (pure jvm) library
+    // api: contracts only — api + (pure jvm) library + kmp.api
     registry.register(
         TargetRegistration(
             type = t.api,
-            allowedDependencies = setOf(t.api, t.library)
+            allowedDependencies = setOf(t.api, t.library, k.api)
         )
     )
 
-    // impl: impl may use contracts + shared + utils; **no other impl**
+    // impl: impl may use contracts + shared + utils + KMP stack; **no other impl**
     registry.register(
         TargetRegistration(
             type = t.impl,
-            allowedDependencies = setOf(t.api, t.library, t.util, t.testUtil)
+            allowedDependencies = setOf(
+                t.api, t.library, t.util, t.testUtil,
+                k.api, k.library, k.util,
+            )
         )
     )
 
-    // library (pure JVM): only util + test-util (parity with existing android jvm.library row)
+    // library (pure JVM): util + test-util + shared KMP library/util
     registry.register(
         TargetRegistration(
             type = t.library,
-            allowedDependencies = setOf(t.util, t.testUtil)
+            allowedDependencies = setOf(t.util, t.testUtil, k.library, k.util)
         )
     )
 
-    // util: utilities may depend on other utils + libraries
+    // util: utilities may depend on other utils + libraries + shared KMP
     registry.register(
         TargetRegistration(
             type = t.util,
-            allowedDependencies = setOf(t.util, t.library)
+            allowedDependencies = setOf(t.util, t.library, k.library, k.util)
         )
     )
 
@@ -68,11 +75,14 @@ fun registerJvmDefaults(registry: TargetRegistry = JvmTargetRegistry) {
         )
     )
 
-    // binary (composition root): wires api + multiple impls + shared library/util for a runnable JVM app
+    // binary (composition root): wires api + multiple impls + shared library/util + KMP
     registry.register(
         TargetRegistration(
             type = t.binary,
-            allowedDependencies = setOf(t.api, t.impl, t.library, t.util, t.testUtil)
+            allowedDependencies = setOf(
+                t.api, t.impl, t.library, t.util, t.testUtil,
+                k.api, k.library, k.util,
+            )
         )
     )
 }

--- a/plugins/jvm/src/test/java/tools/forma/jvm/target/JvmTargetRegistryKmpEdgesTest.kt
+++ b/plugins/jvm/src/test/java/tools/forma/jvm/target/JvmTargetRegistryKmpEdgesTest.kt
@@ -1,0 +1,104 @@
+package tools.forma.jvm.target
+
+import tools.forma.core.target.TargetRef
+import tools.forma.core.validation.FormaValidationException
+import tools.forma.kmp.target.KmpTargetTypes
+import kotlin.test.BeforeTest
+import kotlin.test.Test
+import kotlin.test.assertFailsWith
+import kotlin.test.assertFalse
+import kotlin.test.assertTrue
+
+/**
+ * F-108: JVM consumers → kmp.* restriction edges (docs/KMP-TARGETS.md §6.2).
+ *
+ * Prefer graph-level [isAllowed] for design matrix truth. Suffix overlap note:
+ * `*-kmp-api` ends with `-api`, `*-kmp-library` with `-library`, `*-kmp-util` with `-util`.
+ */
+class JvmTargetRegistryKmpEdgesTest {
+
+    private data class TestRef(override val name: String) : TargetRef
+
+    @BeforeTest
+    fun setup() {
+        registerJvmDefaults()
+    }
+
+    @Test
+    fun `restriction graph encodes jvm to kmp consumer matrix`() {
+        val t = JvmTargetTypes
+        val k = KmpTargetTypes
+        val g = JvmTargetRegistry.restrictionGraph()
+
+        // api → kmp.api only
+        assertTrue(g.isAllowed(t.api, k.api))
+        assertFalse(g.isAllowed(t.api, k.library))
+        assertFalse(g.isAllowed(t.api, k.util))
+        assertFalse(g.isAllowed(t.api, k.testUtil))
+
+        // impl / binary → kmp.api, kmp.library, kmp.util
+        for (consumer in listOf(t.impl, t.binary)) {
+            assertTrue(g.isAllowed(consumer, k.api))
+            assertTrue(g.isAllowed(consumer, k.library))
+            assertTrue(g.isAllowed(consumer, k.util))
+            assertFalse(g.isAllowed(consumer, k.testUtil))
+        }
+
+        // library / util → kmp.library, kmp.util (not kmp.api)
+        for (consumer in listOf(t.library, t.util)) {
+            assertFalse(g.isAllowed(consumer, k.api))
+            assertTrue(g.isAllowed(consumer, k.library))
+            assertTrue(g.isAllowed(consumer, k.util))
+            assertFalse(g.isAllowed(consumer, k.testUtil))
+        }
+
+        // test-util: no kmp edges in v1 §6.2
+        assertFalse(g.isAllowed(t.testUtil, k.api))
+        assertFalse(g.isAllowed(t.testUtil, k.library))
+        assertFalse(g.isAllowed(t.testUtil, k.util))
+        assertFalse(g.isAllowed(t.testUtil, k.testUtil))
+
+        // Existing JVM edges stay intact (spot-check)
+        assertTrue(g.isAllowed(t.api, t.api))
+        assertTrue(g.isAllowed(t.api, t.library))
+        assertFalse(g.isAllowed(t.impl, t.impl))
+        assertTrue(g.isAllowed(t.binary, t.impl))
+    }
+
+    @Test
+    fun `validators accept kmp project names for allowed consumers`() {
+        val t = JvmTargetTypes
+
+        JvmTargetRegistry.validatorFor(t.api).validate(TestRef("core-kmp-api"))
+
+        val implV = JvmTargetRegistry.validatorFor(t.impl)
+        implV.validate(TestRef("core-kmp-api"))
+        implV.validate(TestRef("shared-kmp-library"))
+        implV.validate(TestRef("net-kmp-util"))
+
+        val libV = JvmTargetRegistry.validatorFor(t.library)
+        libV.validate(TestRef("shared-kmp-library"))
+        libV.validate(TestRef("net-kmp-util"))
+
+        val utilV = JvmTargetRegistry.validatorFor(t.util)
+        utilV.validate(TestRef("shared-kmp-library"))
+        utilV.validate(TestRef("net-kmp-util"))
+
+        val binaryV = JvmTargetRegistry.validatorFor(t.binary)
+        binaryV.validate(TestRef("core-kmp-api"))
+        binaryV.validate(TestRef("shared-kmp-library"))
+        binaryV.validate(TestRef("net-kmp-util"))
+    }
+
+    @Test
+    fun `validators still reject disallowed plain jvm suffixes`() {
+        val t = JvmTargetTypes
+        val apiV = JvmTargetRegistry.validatorFor(t.api)
+        assertFailsWith<FormaValidationException> { apiV.validate(TestRef("feature-impl")) }
+        assertFailsWith<FormaValidationException> { apiV.validate(TestRef("shared-util")) }
+
+        val libV = JvmTargetRegistry.validatorFor(t.library)
+        assertFailsWith<FormaValidationException> { libV.validate(TestRef("feature-api")) }
+        assertFailsWith<FormaValidationException> { libV.validate(TestRef("other-impl")) }
+    }
+}

--- a/plugins/jvm/src/test/java/tools/forma/jvm/target/JvmTargetRegistryTest.kt
+++ b/plugins/jvm/src/test/java/tools/forma/jvm/target/JvmTargetRegistryTest.kt
@@ -80,6 +80,8 @@ class JvmTargetRegistryTest {
         assertTrue(g.isAllowed(t.binary, t.util))
         assertTrue(g.isAllowed(t.binary, t.testUtil))
         assertFalse(g.isAllowed(t.binary, t.binary))
+
+        // F-108 kmp edges covered in JvmTargetRegistryKmpEdgesTest
     }
 
     @Test


### PR DESCRIPTION
## Summary
- Extend `AndroidTargetRegistry` and `JvmTargetRegistry` so platform consumers may depend on KMP types per `docs/KMP-TARGETS.md` §6.2
- Wire `:android` / `:jvm` → `:kmp` for `KmpTargetTypes` only (no `:kmp` → `:android`/`:jvm` cycle)
- Unit tests (graph-first) + `DEPENDENCY-MATRIX.md` code-truth update
- Jacoco: include `kmp` in `coverageReportModules`

### Consumer edges
| Consumer | KMP deps |
|----------|----------|
| android.api / jvm.api | kmp.api |
| android.impl / app / binary | kmp.api, kmp.library, kmp.util |
| android.android-util | kmp.library, kmp.util |
| jvm.impl / binary | kmp.api, kmp.library, kmp.util |
| jvm.library / util | kmp.library, kmp.util |

## Test plan
- [x] `plugins/`: `./gradlew :android:test :jvm:test :kmp:test` → BUILD SUCCESSFUL
- [x] `plugins/`: `./gradlew test jacocoHappyPathCoverageVerification` → BUILD SUCCESSFUL
- [x] Android KmpEdgesTest 3 + JVM KmpEdgesTest 3 green
- [x] Cycle rule: `:kmp` does not depend on `:android`/`:jvm`