### PR TITLE
F-110: KMP getting started + agent skill + curriculum

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,20 +49,21 @@ systems like Buck and Bazel.
 
 1. [**Android project tutorial**](docs/GETTING-STARTED.md) — mental model, run the sample, greenfield skeleton, target cheat sheet (F-015 / GH #53)
 2. [**JVM getting started**](docs/JVM-GETTING-STARTED.md) — pure JVM tutorial, run the sample, greenfield skeleton with `binary`, `api`/`impl`, target cheat sheet (F-032)
-3. [Sample app gold standard](docs/SAMPLE-APP.md) — multi-feature layout to copy
-4. [Dependency matrix](docs/DEPENDENCY-MATRIX.md) — what may depend on what
-5. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins](docs/TARGET-PLUGINS.md) (type-owned, Bazel-like; examples `10-target-plugins`, `11-metro-di`) · [Call-site surface](docs/CALL-SITE-SURFACE.md) (Unit DSLs + flag inventory) · [Fleet tooling](docs/FLEET-TOOLING.md) (check/generate Gradle tasks + core APIs, F-084/F-088) · [Principle audit](docs/PRINCIPLE-AUDIT.md) (F-085) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
-6. [Plugin publish path](docs/PLUGIN-PUBLISH.md) — Portal metadata DSL + release notes (F-016)
-7. [Configuration performance](docs/CONFIGURATION-PERFORMANCE.md) — measure + hot-path guidance (F-017 / GH #106)
-8. [forma-core public API design](docs/forma-core-api.md) — extraction contract for types / restrictions / registry (F-020)
-9. [JVM targets](docs/JVM-TARGETS.md) — pure JVM platform plugin `tools.forma.jvm` (F-030)
-10. [JVM sample application](docs/JVM-SAMPLE.md) — multi-module pure-JVM gold standard (`jvm-application/`, F-031)
-11. [**Kotlin Multiplatform design**](docs/KMP-TARGETS.md) — `tools.forma.kmp` types, matrix, no call-site target shopping (F-105; implement F-106…F-110)
-12. [Bazel adapter design](docs/BAZEL-ADAPTER.md) — target types to rules, restriction graph to visibility (F-040 design)
-13. [Bazel adapter spike](bazel-adapter/README.md) — generate/check BUILD from Forma model (F-041; JVM-first)
-14. [Bazel sample (experimental)](bazel-sample/) — minimal `kt_jvm_*` workspace exercising forma-core matrix + `impl` ↛ `impl` (F-042)
-15. [**Progressive examples + agent skills**](docs/PROGRESSIVE-EXAMPLES.md) — feature-by-feature ladders (`examples/`) + coding-agent skills (F-050)
-16. [**Test coverage**](docs/TEST-COVERAGE.md) — JaCoCo on `plugins/`, happy-path LINE ≥60% gate
+3. [**KMP getting started**](docs/KMP-GETTING-STARTED.md) — shared multiplatform libraries, `kmpProjectConfiguration`, JVM/Android consumers (F-110)
+4. [Sample app gold standard](docs/SAMPLE-APP.md) — multi-feature layout to copy
+5. [Dependency matrix](docs/DEPENDENCY-MATRIX.md) — what may depend on what
+6. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins](docs/TARGET-PLUGINS.md) (type-owned, Bazel-like; examples `10-target-plugins`, `11-metro-di`) · [Call-site surface](docs/CALL-SITE-SURFACE.md) (Unit DSLs + flag inventory) · [Fleet tooling](docs/FLEET-TOOLING.md) (check/generate Gradle tasks + core APIs, F-084/F-088) · [Principle audit](docs/PRINCIPLE-AUDIT.md) (F-085) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
+7. [Plugin publish path](docs/PLUGIN-PUBLISH.md) — Portal metadata DSL + release notes (F-016)
+8. [Configuration performance](docs/CONFIGURATION-PERFORMANCE.md) — measure + hot-path guidance (F-017 / GH #106)
+9. [forma-core public API design](docs/forma-core-api.md) — extraction contract for types / restrictions / registry (F-020)
+10. [JVM targets](docs/JVM-TARGETS.md) — pure JVM platform plugin `tools.forma.jvm` (F-030)
+11. [JVM sample application](docs/JVM-SAMPLE.md) — multi-module pure-JVM gold standard (`jvm-application/`, F-031)
+12. [**Kotlin Multiplatform design**](docs/KMP-TARGETS.md) — `tools.forma.kmp` types, matrix, no call-site target shopping (F-105…F-110 shipped)
+13. [Bazel adapter design](docs/BAZEL-ADAPTER.md) — target types to rules, restriction graph to visibility (F-040 design)
+14. [Bazel adapter spike](bazel-adapter/README.md) — generate/check BUILD from Forma model (F-041; JVM-first)
+15. [Bazel sample (experimental)](bazel-sample/) — minimal `kt_jvm_*` workspace exercising forma-core matrix + `impl` ↛ `impl` (F-042)
+16. [**Progressive examples + agent skills**](docs/PROGRESSIVE-EXAMPLES.md) — feature-by-feature ladders (`examples/`) + coding-agent skills (F-050; KMP skill `forma-kmp-targets`)
+17. [**Test coverage**](docs/TEST-COVERAGE.md) — JaCoCo on `plugins/`, happy-path LINE ≥60% gate
 
 Configuration made easy:
 

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -149,9 +149,9 @@ worker (ops); `v2`→`master` (explicit git promote only). **F-094** stays `bloc
 ## P11 — Kotlin Multiplatform (Stepan 2026-07-25)
 
 Third Gradle platform on forma-core (`tools.forma.kmp`). **Design:** [`docs/KMP-TARGETS.md`](docs/KMP-TARGETS.md).
-**User priority (2026-07-25):** implement **F-107** next (before F-100…F-104) unless a hotfix blocks.
-v1 = **jvm + android** shared libraries only; type-owned MPP; **no** per-module target shopping;
-composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
+**P11 v1 complete (F-105…F-110).** Next board priority returns to **P10** top `todo` (**F-100**…) unless
+Stepan reprioritizes. v1 = **jvm + android** shared libraries only; type-owned MPP; **no** per-module
+target shopping; composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
@@ -160,7 +160,7 @@ composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 | F-107 | done | Apply kotlin-multiplatform + `kmpLibrary` DSL | `kmpProjectConfiguration` + feature applicator (`com.android.kotlin.multiplatform.library` + jvm); `kmpLibrary`/`kmpApi`/`kmpUtil`/`kmpTestUtil`; commonMain deps; unit tests; plugins jacoco green |
 | F-108 | done | Android/JVM consumer matrix edges → kmp.* | Extend `AndroidTargetRegistry` + `JvmTargetRegistry`; update `DEPENDENCY-MATRIX.md` from code; avoid `:kmp`→`:android` cycle |
 | F-109 | done | Progressive example `examples/kmp/01-shared-library` | Shared `kmp-library` + JVM binary consumer; pure KMP+JVM platforms; `./gradlew build` + `:binary:run` green |
-| F-110 | todo | KMP user docs + agent skill + curriculum | `KMP-GETTING-STARTED.md`, `examples/agent-skills/forma-kmp-targets.md`, PROGRESSIVE-EXAMPLES ladder, README |
+| F-110 | done | KMP user docs + agent skill + curriculum | `docs/KMP-GETTING-STARTED.md`; `examples/agent-skills/forma-kmp-targets.md`; PROGRESSIVE-EXAMPLES + README + overview skill links |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/KMP-GETTING-STARTED.md
+++ b/docs/KMP-GETTING-STARTED.md
@@ -1,0 +1,378 @@
+# Getting started — Kotlin Multiplatform with Forma (F-110)
+
+Forma is a **meta build system**. For shared multiplatform code you declare
+**KMP targets** (`kmpLibrary`, `kmpApi`, …) instead of hand-wiring
+`kotlin("multiplatform")`, per-module `kotlin { targets { … } }`, and ad-hoc
+visibility. The **target type owns** the multiplatform plugin and the platform
+set. Call sites stay attributes-only (`packageName`, `dependencies`, …).
+
+This tutorial gets you from zero to a working **shared KMP library + JVM
+consumer**. Design and matrix truth: [KMP-TARGETS.md](KMP-TARGETS.md). Live
+validator tables (including Android/JVM → KMP): [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md).
+
+---
+
+## 1. Mental model (5 minutes)
+
+| Concept | Meaning |
+|---------|---------|
+| **KMP target** | One Gradle project with a Forma KMP type (`kmp.library`, `kmp.api`, …). |
+| **Suffix** | Project/folder name **must** end in the KMP-prefixed suffix (`…-kmp-library`, `…-kmp-api`, …). Plain `…-library` is **JVM** `library`, not KMP. |
+| **Platforms** | Chosen **once** in root `kmpProjectConfiguration` (v1: `jvm` and/or `android`). Never listed per module. |
+| **Composition root** | Still Android/JVM: `androidBinary` / `androidApp` / JVM `binary`. **No** `kmpBinary` / `kmpImpl` in v1. |
+| **commonMain** | Shared sources live under `src/commonMain/kotlin/…` (not `src/main`). |
+
+**What Forma does for each KMP target**
+
+1. Validates the project name matches the KMP suffix.
+2. Applies `org.jetbrains.kotlin.multiplatform` (and, when android platform is on, `com.android.kotlin.multiplatform.library`).
+3. Creates the project-global platform set (jvm / android) — no call-site shopping.
+4. Enforces **project** deps against the KMP matrix and (for consumers) Android/JVM → KMP edges.
+
+You still write Kotlin and choose multiplatform library coordinates — Forma owns
+structure, plugins, and boundaries.
+
+### Rejected shapes (do not teach)
+
+```kotlin
+// REJECTED — raw KMP at every module
+plugins { kotlin("multiplatform") }
+kotlin { androidTarget(); jvm(); iosArm64() }
+
+// REJECTED — platforms / plugins as call-site attrs
+kmpLibrary(..., platforms = listOf("ios", "jvm"))
+
+// REJECTED — restore androidLibrary as “shared”
+androidLibrary(...) // removed F-063
+```
+
+---
+
+## 2. Prerequisites
+
+| Tool | Version / notes |
+|------|-----------------|
+| JDK | **17+** host; KMP/JVM compile target defaults to **11** |
+| Android SDK | **Only** if `KmpPlatforms(android = true)` (needs `androidProjectConfiguration`) |
+| Build tools | Gradle wrapper (repo baseline **9.6.x** / Kotlin **2.3.x** / AGP **9.3.x** when Android is on) |
+
+```bash
+source scripts/env-mac.sh   # repo helper — exports JAVA_HOME (+ SDK when present)
+```
+
+Pure KMP+JVM trees (example 01) do **not** need the Android SDK.
+
+---
+
+## 3. Path A — run the progressive example first (recommended)
+
+```bash
+git clone https://github.com/formatools/forma.git
+cd forma
+source scripts/env-mac.sh
+
+cd examples/kmp/01-shared-library
+./gradlew build
+./gradlew :binary:run
+```
+
+Expected:
+
+```
+Hello, World — from Forma KMP shared library
+KMP 01 (shared-library) build + run successful.
+
+BUILD SUCCESSFUL
+```
+
+| Path | Role |
+|------|------|
+| `build.gradle.kts` | Root `kmpProjectConfiguration` once (`jvm=true`, `android=false`) |
+| `shared-kmp-library/` | `kmpLibrary` + `src/commonMain/kotlin/…` |
+| `binary/` | JVM `binary` composition root → `target(":shared-kmp-library")` |
+| `settings.gradle.kts` | `tools.forma.kmp` + `tools.forma.jvm` + includer |
+
+Step README: [examples/kmp/01-shared-library](../examples/kmp/01-shared-library).
+
+---
+
+## 4. Path B — greenfield skeleton (pure KMP + JVM)
+
+Published plugin id: `tools.forma.kmp` (develop via composite `includeBuild` in this monorepo). Companion: `tools.forma.jvm` (consumer) + `tools.forma.includer`.
+
+### 4.1 `settings.gradle.kts`
+
+**Monorepo / composite** (matches example 01):
+
+```kotlin
+pluginManagement {
+    repositories {
+        gradlePluginPortal()
+        mavenCentral()
+    }
+    includeBuild("../plugins")
+    includeBuild("../includer")
+    includeBuild("../build-settings")
+    apply(from = "../build-settings/conventions/src/main/kotlin/convention-plugins.settings.gradle.kts")
+}
+
+plugins {
+    id("convention-dependencies")
+    id("tools.forma.includer")
+    id("tools.forma.jvm")
+    id("tools.forma.kmp")
+}
+
+includer { arbitraryBuildScriptNames = true }
+rootProject.name = "my-kmp-app"
+```
+
+Portal path (when published): same plugin ids with `version "…"`.
+
+### 4.2 Root `build.gradle.kts`
+
+`kmpProjectConfiguration` lives in the **default package** (parity with
+`androidProjectConfiguration`) so it resolves inside `buildscript { }` without
+imports under Gradle Kotlin DSL.
+
+```kotlin
+// Platforms once for the whole product — modules never re-list targets.
+buildscript {
+    kmpProjectConfiguration(
+        project = rootProject,
+        platforms = tools.forma.kmp.settings.KmpPlatforms(jvm = true, android = false),
+        // jvmTarget = "11", // default
+    )
+}
+```
+
+**Defaults** if you omit `platforms`: **both** `jvm` and `android` are **on**.
+Android-on requires a prior/sibling `androidProjectConfiguration` (SDK pins) or
+apply fails fast.
+
+### 4.3 Shared library + JVM binary
+
+```
+my-kmp-app/
+├── settings.gradle.kts
+├── build.gradle.kts
+├── shared-kmp-library/
+│   ├── build.gradle.kts
+│   └── src/commonMain/kotlin/com/example/shared/Greeting.kt
+└── binary/
+    ├── build.gradle.kts
+    └── src/main/kotlin/com/example/binary/Main.kt
+```
+
+**`shared-kmp-library/build.gradle.kts`**
+
+```kotlin
+import tools.forma.kmp.kmpLibrary
+
+kmpLibrary(packageName = "com.example.shared")
+```
+
+**`binary/build.gradle.kts`**
+
+```kotlin
+import tools.forma.jvm.binary
+
+binary(
+    packageName = "com.example.binary",
+    mainClass = "com.example.binary.MainKt",
+    dependencies = deps(
+        target(":shared-kmp-library"),
+    ),
+)
+```
+
+Sources:
+
+- KMP: `src/commonMain/kotlin/<package-as-dirs>/…` matching `packageName`
+- JVM binary: `src/main/kotlin/…` as usual
+
+### 4.4 Build / run
+
+```bash
+./gradlew build
+./gradlew :binary:run
+```
+
+---
+
+## 5. Target cheat sheet
+
+| DSL | Type id | Name suffix | Role |
+|-----|---------|-------------|------|
+| `kmpLibrary` | `kmp.library` | `kmp-library` | Shared multiplatform library (default workhorse) |
+| `kmpApi` | `kmp.api` | `kmp-api` | Shared public contracts |
+| `kmpUtil` | `kmp.util` | `kmp-util` | Shared utilities |
+| `kmpTestUtil` | `kmp.test-util` | `kmp-test-util` | Shared test helpers (`testDependencies`) |
+
+**Not in v1:** `kmpImpl`, `kmpBinary`, iOS/JS/Wasm, per-module platform lists.
+
+Imports: `tools.forma.kmp.kmpLibrary` (and siblings). Plugin id: `tools.forma.kmp`.
+
+---
+
+## 6. Declaring dependencies
+
+### On a KMP module (→ commonMain)
+
+```kotlin
+import tools.forma.kmp.kmpLibrary
+import tools.forma.deps.core.deps
+
+kmpLibrary(
+    packageName = "com.example.shared",
+    dependencies = deps(
+        target(":core-kmp-api"),
+        // external multiplatform GAVs / libs.* catalog entries
+    ),
+    testDependencies = deps(
+        // commonTest
+    ),
+)
+```
+
+Platform-only dep attrs (`androidDependencies` / `jvmDependencies`) are **deferred** in v1 — prefer common code or platform consumers.
+
+### From Android / JVM consumers → KMP
+
+```kotlin
+// Android feature impl
+impl(
+    packageName = "com.example.hello.impl",
+    dependencies = deps(
+        target(":shared-kmp-library"),
+        target(":feature-hello-api"),
+    ),
+)
+
+// JVM binary (example 01)
+binary(
+    packageName = "com.example.binary",
+    mainClass = "com.example.binary.MainKt",
+    dependencies = deps(target(":shared-kmp-library")),
+)
+```
+
+Allow-lists (summary):
+
+| Consumer | May depend on |
+|----------|----------------|
+| `android.api` / `jvm.api` | `kmp.api` |
+| `android.impl` / `app` / `binary` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `jvm.impl` / `jvm.binary` | `kmp.api`, `kmp.library`, `kmp.util` |
+| `jvm.library` / `jvm.util` | `kmp.library`, `kmp.util` |
+
+Full tables: [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md) · design [KMP-TARGETS.md](KMP-TARGETS.md) §6.
+
+**Directionality:** KMP must **not** depend on Android `impl` / UI / `res` or JVM `impl`. Shared code stays leaf-ish toward platforms.
+
+---
+
+## 7. Mobile monorepo (Android + KMP)
+
+When both platforms are enabled:
+
+```kotlin
+buildscript {
+    androidProjectConfiguration(
+        project = rootProject,
+        minSdk = 26,
+        targetSdk = 37,
+        compileSdk = 37,
+        agpVersion = "9.3.0",
+        // …
+    )
+    kmpProjectConfiguration(
+        project = rootProject,
+        // defaults: KmpPlatforms(jvm = true, android = true)
+    )
+}
+```
+
+| Concern | Source of truth |
+|---------|-----------------|
+| minSdk / compileSdk / AGP | `androidProjectConfiguration` |
+| KMP platforms | `kmpProjectConfiguration` only |
+| Kotlin version | Align with Android/Forma settings — do not introduce a second pin |
+| JVM target | Default `"11"`; align with `javaVersionCompatibility` |
+
+Settings plugins typically include `tools.forma.android`, `tools.forma.kmp`, and often `tools.forma.jvm` if you also have pure-JVM binaries.
+
+---
+
+## 8. Rules that bite on day one
+
+1. **Suffix must be KMP-prefixed** — `shared-kmp-library`, not `shared-library`.
+2. **Platforms once** — never `kotlin { jvm(); androidTarget() }` in a module.
+3. **Composition at Android/JVM roots** — wire KMP from `impl` / `binary` / `app`, not via a fake KMP app type.
+4. **`impl` ↛ `impl` still holds** on Android/JVM; KMP does not create a back door.
+5. **No KMP → platform UI/impl** — keep shared code free of Android/JVM feature leaves.
+6. **Sources under `commonMain`** (and optional `androidMain` / `jvmMain` for actuals) — not `src/main` on KMP modules.
+7. **No `res/` in common** — Android resources stay `androidRes` / platform UI targets.
+8. **`:kmp` plugin must not depend on `:android`** (engine cycle rule) — consumers depend on KMP types; fine.
+
+---
+
+## 9. Day-to-day workflow
+
+```bash
+# Progressive example
+cd examples/kmp/01-shared-library
+./gradlew build
+./gradlew :binary:run
+
+# Plugins unit + happy-path coverage (contributors)
+cd plugins
+./gradlew :kmp:test test jacocoHappyPathCoverageVerification
+```
+
+- Prefer small `kmp-library` / `kmp-api` slices over one fat shared module.
+- Expect/actual only at real platform edges; prefer expect-free common when possible.
+- When a validator fails, fix the **edge or type** — do not disable validation.
+
+---
+
+## 10. Common pitfalls
+
+| Symptom | Likely cause |
+|---------|----------------|
+| Wrong type / suffix validation | Folder not ending in `kmp-library` / `kmp-api` / … |
+| Unresolved `kmpProjectConfiguration` in `buildscript` | Expect default-package API; do not put it only under a nested package import inside `buildscript` |
+| Android platform apply fails | `android = true` without `androidProjectConfiguration` / SDK |
+| Illegal project dependency | Matrix — see DEPENDENCY-MATRIX / KMP-TARGETS §6 |
+| Trying to apply MPP in the module | Type owns plugins — remove raw `plugins { kotlin("multiplatform") }` |
+| `src/main` empty on KMP module | Use `src/commonMain/kotlin/…` |
+| iOS / JS targets | Out of scope for v1 |
+
+---
+
+## 11. Next reading
+
+| Doc | Topic |
+|-----|--------|
+| [KMP-TARGETS.md](KMP-TARGETS.md) | Full design: types, platforms, matrix, rejected shapes |
+| [DEPENDENCY-MATRIX.md](DEPENDENCY-MATRIX.md) | Live allow-lists (KMP + consumer edges) |
+| [PROGRESSIVE-EXAMPLES.md](PROGRESSIVE-EXAMPLES.md) | Ladders + agent skills index |
+| [JVM-GETTING-STARTED.md](JVM-GETTING-STARTED.md) | Pure JVM tutorial (composition roots) |
+| [GETTING-STARTED.md](GETTING-STARTED.md) | Android tutorial |
+| [TARGET-PLUGINS.md](TARGET-PLUGINS.md) | Type-owned external plugins (Path A/B) |
+| [VISION.md](VISION.md) | Root principles + platform sequencing |
+| [ENV.md](ENV.md) | JDK / SDK bootstrap |
+
+Agent skill: [forma-kmp-targets](../examples/agent-skills/forma-kmp-targets.md).
+
+---
+
+## 12. Checklist — “I’m using Forma KMP correctly”
+
+- [ ] Settings apply `tools.forma.kmp` (and consumer platform plugins as needed)
+- [ ] Root calls `kmpProjectConfiguration` **once** (platforms not re-listed on modules)
+- [ ] Shared modules use `kmpLibrary` / `kmpApi` / … with **`*-kmp-*` suffixes**
+- [ ] Sources under `src/commonMain/kotlin/…` matching `packageName`
+- [ ] No raw `kotlin { targets { } }` / per-module plugin shopping
+- [ ] Apps/features compose on Android/JVM roots; they depend **on** KMP, not the reverse for UI/impl
+- [ ] `./gradlew build` (and consumer run/assemble) succeeds on a clean machine with the right JDK/(SDK)

--- a/docs/KMP-TARGETS.md
+++ b/docs/KMP-TARGETS.md
@@ -1,6 +1,7 @@
 # Kotlin Multiplatform (KMP) targets — design (F-105)
 
-**Status:** design accepted (F-105). Implementation: **F-106…F-110** (see `TICKETS.md` § P11).
+**Status:** design accepted (F-105). Implementation **F-106…F-110 done** (see `TICKETS.md` § P11).
+User tutorial: [`KMP-GETTING-STARTED.md`](KMP-GETTING-STARTED.md) · agent skill: [`forma-kmp-targets`](../examples/agent-skills/forma-kmp-targets.md).
 
 **North star:** KMP is a **third platform adapter** on forma-core (after Android + pure JVM), not a free-form
 `kotlin { targets { … } }` escape hatch. Call sites stay **Bazel-like**: type + attributes. The
@@ -349,7 +350,7 @@ requires Android settings present or fails fast with a clear error.
 | **F-107** | Feature applicator: apply KMP (+ Android KMP lib), jvm+android targets, source sets, `kmpLibrary` DSL + deps apply path | Unit tests + compile; minimal smoke module if feasible |
 | **F-108** | Extend Android + JVM restriction matrices to allow KMP deps; docs matrix | Registry unit tests; sample edge compile |
 | **F-109** | Progressive example `examples/kmp/01-shared-library` (shared kmp-library + jvm binary and/or tiny android binary consumer) | **Done** — pure KMP+JVM (`KmpPlatforms(jvm=true, android=false)`); `./gradlew build` + `:binary:run` green. See example README. |
-| **F-110** | User docs (`KMP-GETTING-STARTED` or section), agent skill, PROGRESSIVE-EXAMPLES ladder, README links | Doc-only + example already green |
+| **F-110** | User docs (`KMP-GETTING-STARTED`), agent skill, PROGRESSIVE-EXAMPLES ladder, README links | **Done** — `docs/KMP-GETTING-STARTED.md` + `examples/agent-skills/forma-kmp-targets.md` + curriculum/README links |
 
 Do **not** merge F-107 without a written spike note in PROGRESS if the Android KMP library plugin
 API differs from this doc — update §4.3 in the same PR.
@@ -432,6 +433,9 @@ feature/hello/impl/          # existing android impl
 
 ## 12. See also
 
+- User tutorial: [`KMP-GETTING-STARTED.md`](KMP-GETTING-STARTED.md)
+- Progressive example: [`examples/kmp/01-shared-library`](../examples/kmp/01-shared-library)
+- Agent skill: [`forma-kmp-targets`](../examples/agent-skills/forma-kmp-targets.md)
 - Implementation plan (Hermes): `.hermes/plans/*-kmp-multiplatform.md` (workspace)
 - JVM precedent: [`JVM-TARGETS.md`](JVM-TARGETS.md), `plugins/jvm/`
 - Target plugins: [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md)

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,20 @@
 
 Newest entries first.
 
+## 2026-07-25 — F-110: KMP user docs + agent skill + curriculum
+
+- **Ticket:** F-110 → `done` (P11 v1 complete; next board **F-100**)
+- **Branch:** `forma/F-110-kmp-docs` (from `origin/v2` @ F-109)
+- **Docs / skills:**
+  - `docs/KMP-GETTING-STARTED.md` — mental model, Path A example 01, Path B greenfield, cheat sheet, consumer edges, mobile monorepo, pitfalls, checklist
+  - `examples/agent-skills/forma-kmp-targets.md` — DSL/suffix/platforms/matrix rejects + skeleton
+  - Curriculum links: `PROGRESSIVE-EXAMPLES.md`, `examples/agent-skills/README.md` + `forma-overview.md`, `README.md` (KMP tutorial #3), `KMP-TARGETS.md` status + §8/§12, example 01 README Next
+  - `TICKETS.md` P11 header: v1 complete; resume P10 **F-100**
+- **Code:** docs/curriculum only (no engine changes)
+- **Verify (real host):** `examples/kmp/01-shared-library` `./gradlew build` + `:binary:run` (sanity after docs; product already green on F-109)
+- **Skills/modes:** Hermes direct (architecture/docs class; F-110 mechanical curriculum)
+- **Next step:** F-100 — Gradle project on buildscript classpath (GH #111)
+
 ## 2026-07-25 — F-109: Progressive example `examples/kmp/01-shared-library`
 
 - **Ticket:** F-109 → `done` (next F-110 KMP user docs + agent skill)

--- a/docs/PROGRESSIVE-EXAMPLES.md
+++ b/docs/PROGRESSIVE-EXAMPLES.md
@@ -7,10 +7,10 @@ narrative tutorials when you want a **minimal buildable project per concept**.
 |----------|-------|
 | Humans learning Android Forma | [examples/android/01-hello-apk](../examples/android/01-hello-apk) then climb |
 | Humans learning JVM Forma | [examples/jvm/01-hello-binary](../examples/jvm/01-hello-binary) |
-| Humans learning KMP Forma | [examples/kmp/01-shared-library](../examples/kmp/01-shared-library) |
+| Humans learning KMP Forma | [examples/kmp/01-shared-library](../examples/kmp/01-shared-library) + [KMP-GETTING-STARTED.md](KMP-GETTING-STARTED.md) |
 | Coding agents | [examples/agent-skills/](../examples/agent-skills/) |
 | Full product reference | [SAMPLE-APP.md](SAMPLE-APP.md) / [JVM-SAMPLE.md](JVM-SAMPLE.md) |
-| Narrative tutorials | [GETTING-STARTED.md](GETTING-STARTED.md) / [JVM-GETTING-STARTED.md](JVM-GETTING-STARTED.md) |
+| Narrative tutorials | [GETTING-STARTED.md](GETTING-STARTED.md) / [JVM-GETTING-STARTED.md](JVM-GETTING-STARTED.md) / [KMP-GETTING-STARTED.md](KMP-GETTING-STARTED.md) |
 
 ## Feature coverage matrix
 
@@ -33,8 +33,8 @@ narrative tutorials when you want a **minimal buildable project per concept**.
 | `androidTestUtil` | 09 | — | — | forma-android-targets |
 | Type-owned target plugins (`navigationRes` Path B) | 10 | — | — | forma-target-plugins |
 | Metro DI (`metroImpl` / `metroApp`, Path A on impl/app) | 11 | — | — | forma-target-plugins |
-| `kmpLibrary` + `kmpProjectConfiguration` | — | — | 01 | F-110 (`forma-kmp-targets`) |
-| JVM/Android → `kmp.*` consumer edge | — | — | 01 (JVM binary) | F-110 |
+| `kmpLibrary` + `kmpProjectConfiguration` | — | — | 01 | forma-kmp-targets |
+| JVM/Android → `kmp.*` consumer edge | — | — | 01 (JVM binary) | forma-kmp-targets |
 | Fleet check/generate/migrate (`tools.forma.core.fleet`) | docs | docs | — | forma-fleet-tooling |
 | `androidNative` | skill/docs | — | — | forma-android-targets |
 | Bazel adapter / sample | skill | skill | — | forma-bazel |

--- a/examples/agent-skills/README.md
+++ b/examples/agent-skills/README.md
@@ -8,6 +8,7 @@ matrix rules, and progressive example pointers.
 | [forma-overview](forma-overview.md) | Any Forma work; entry map |
 | [forma-android-targets](forma-android-targets.md) | Creating/editing Android targets |
 | [forma-jvm-targets](forma-jvm-targets.md) | Pure JVM targets |
+| [forma-kmp-targets](forma-kmp-targets.md) | KMP shared libraries (`kmpLibrary`, platforms once) |
 | [forma-dependency-matrix](forma-dependency-matrix.md) | Dependency / visibility errors |
 | [forma-deps-catalog](forma-deps-catalog.md) | External deps / catalogs |
 | [forma-target-plugins](forma-target-plugins.md) | External plugins on types (Path A/B); never `.withPlugin` |

--- a/examples/agent-skills/forma-kmp-targets.md
+++ b/examples/agent-skills/forma-kmp-targets.md
@@ -1,0 +1,68 @@
+---
+name: forma-kmp-targets
+description: Kotlin Multiplatform Forma DSL targets, kmpProjectConfiguration, and KMP ladder.
+---
+
+# KMP targets (agent skill)
+
+Plugin: `tools.forma.kmp`. Imports: `tools.forma.kmp.kmpLibrary`, `.kmpApi`, `.kmpUtil`, `.kmpTestUtil`.
+
+Root config (default package, inside `buildscript { }`): `kmpProjectConfiguration(project, platforms, jvmTarget)`.
+
+| DSL | Suffix | Role | Step |
+|-----|--------|------|------|
+| `kmpLibrary` | `kmp-library` | shared MPP library | 01 |
+| `kmpApi` | `kmp-api` | shared contracts | (later ladder) |
+| `kmpUtil` | `kmp-util` | shared helpers | (later) |
+| `kmpTestUtil` | `kmp-test-util` | shared test helpers | (later) |
+
+**No v1:** `kmpImpl`, `kmpBinary`, iOS/JS/Wasm, per-module `kotlin { targets }`.
+
+## Platforms (one global way)
+
+```kotlin
+buildscript {
+  kmpProjectConfiguration(
+    project = rootProject,
+    platforms = tools.forma.kmp.settings.KmpPlatforms(jvm = true, android = false),
+  )
+}
+// Defaults if omitted: jvm=true, android=true (requires androidProjectConfiguration when android on)
+```
+
+Type owns `org.jetbrains.kotlin.multiplatform` (+ `com.android.kotlin.multiplatform.library` when android).
+
+## Matrix rules of thumb
+
+**KMP → KMP:** api→api; library→api/library/util; util→util; test-util→api/library/util/test-util.
+
+**Consumers → KMP:** android/jvm `api`→`kmp.api`; impl/app/binary→api+library+util.  
+**Never:** KMP → android/jvm `impl` / UI / `res`.  
+**Never:** restore `androidLibrary` as shared bucket.
+
+## Skeleton
+
+```kotlin
+// shared-kmp-library/build.gradle.kts
+import tools.forma.kmp.kmpLibrary
+kmpLibrary(packageName = "com.example.shared")
+
+// binary/build.gradle.kts (JVM composition root)
+import tools.forma.jvm.binary
+binary(
+  packageName = "com.example.binary",
+  mainClass = "com.example.binary.MainKt",
+  dependencies = deps(target(":shared-kmp-library")),
+)
+```
+
+Sources: `src/commonMain/kotlin/…` on KMP modules (not `src/main`).
+
+## Hard rejects
+
+1. Call-site platform lists / raw `kotlin { androidTarget(); ios() }`
+2. `.withPlugin` / free-form plugin ids on KMP modules
+3. `impl` → `impl` via “shared” fat modules that pull UI
+4. Suffix `*-library` without `kmp-` prefix (that is JVM `library`)
+
+Examples: `examples/kmp/01-shared-library`. Design: `docs/KMP-TARGETS.md`. Tutorial: `docs/KMP-GETTING-STARTED.md`. Matrix: `docs/DEPENDENCY-MATRIX.md`.

--- a/examples/agent-skills/forma-overview.md
+++ b/examples/agent-skills/forma-overview.md
@@ -14,15 +14,16 @@ shared configuration, and a **dependency restriction graph**.
 
 | Plugin id | Module | Sample | Progressive ladder |
 |-----------|--------|--------|--------------------|
-| `tools.forma.android` | `plugins/android` | `application/` | `examples/android/01`…`10` |
+| `tools.forma.android` | `plugins/android` | `application/` | `examples/android/01`…`11` |
 | `tools.forma.jvm` | `plugins/jvm` | `jvm-application/` | `examples/jvm/01`…`05` |
+| `tools.forma.kmp` | `plugins/kmp` | — | `examples/kmp/01` |
 | `tools.forma:core` | `plugins/core` | — | restriction engine + fleet toolkit |
 | Bazel adapter | `bazel-adapter/` | `bazel-sample/` | skill `forma-bazel` |
 
 ## Learning order for agents
 
 1. This overview + `forma-includer-settings` + `forma-project-layout`
-2. Platform targets (`forma-android-targets` or `forma-jvm-targets`)
+2. Platform targets (`forma-android-targets`, `forma-jvm-targets`, and/or `forma-kmp-targets`)
 3. `forma-dependency-matrix` before multi-module wiring
 4. `forma-deps-catalog` (house style) / `forma-compose` as needed
 5. `forma-target-plugins` before any third-party Gradle plugin
@@ -32,9 +33,10 @@ shared configuration, and a **dependency restriction graph**.
 ## Docs of record
 
 - `docs/VISION.md` — root principles
-- `docs/DEPENDENCY-MATRIX.md` — live validator truth (Android)
+- `docs/DEPENDENCY-MATRIX.md` — live validator truth (Android + JVM + KMP edges)
 - `docs/JVM-TARGETS.md` — JVM matrix
-- `docs/GETTING-STARTED.md` / `docs/JVM-GETTING-STARTED.md`
+- `docs/KMP-TARGETS.md` — KMP design + matrix
+- `docs/GETTING-STARTED.md` / `docs/JVM-GETTING-STARTED.md` / `docs/KMP-GETTING-STARTED.md`
 - `docs/PROGRESSIVE-EXAMPLES.md`
 - `docs/CALL-SITE-SURFACE.md` — Unit DSLs, flags, removed chain API
 - `docs/PROJECT-CONFIGURATION.md` — single `androidProjectConfiguration` path

--- a/examples/kmp/01-shared-library/README.md
+++ b/examples/kmp/01-shared-library/README.md
@@ -50,7 +50,9 @@ BUILD SUCCESSFUL
 ## Non-goals (this step)
 - Android consumer / `android = true` platforms (optional later; needs `androidProjectConfiguration` + AGP)
 - `kmpApi` / `kmpUtil` / expect-actual
-- Full KMP getting-started docs and agent skill (F-110)
 
 ## Next
-F-110 curriculum docs. Broader KMP ladder may add api/util and Android consumer steps later.
+- Tutorial: [`docs/KMP-GETTING-STARTED.md`](../../../docs/KMP-GETTING-STARTED.md)
+- Agent skill: [`forma-kmp-targets`](../../agent-skills/forma-kmp-targets.md)
+- Design/matrix: [`docs/KMP-TARGETS.md`](../../../docs/KMP-TARGETS.md)
+- Broader KMP ladder may add api/util and Android consumer steps later.


### PR DESCRIPTION
## Summary
- Add `docs/KMP-GETTING-STARTED.md` (Path A example 01, Path B greenfield, matrix/consumer edges, pitfalls)
- Add `examples/agent-skills/forma-kmp-targets.md` and wire curriculum (PROGRESSIVE-EXAMPLES, README, overview skill, KMP-TARGETS status)
- Mark **F-110 done**; P11 v1 complete — next board **F-100**

## Test plan
- [x] `examples/kmp/01-shared-library` `./gradlew build` + `:binary:run` (expected greeting printed)
- Docs-only slice (no engine changes)