### PR TITLE
F-102: navigation abstraction design

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ systems like Buck and Bazel.
 3. [**KMP getting started**](docs/KMP-GETTING-STARTED.md) — shared multiplatform libraries, `kmpProjectConfiguration`, JVM/Android consumers (F-110)
 4. [Sample app gold standard](docs/SAMPLE-APP.md) — multi-feature layout to copy
 5. [Dependency matrix](docs/DEPENDENCY-MATRIX.md) — what may depend on what
-6. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins](docs/TARGET-PLUGINS.md) (type-owned, Bazel-like; examples `10-target-plugins`, `11-metro-di`) · [Call-site surface](docs/CALL-SITE-SURFACE.md) (Unit DSLs + flag inventory) · [Fleet tooling](docs/FLEET-TOOLING.md) (check/generate Gradle tasks + core APIs, F-084/F-088) · [Principle audit](docs/PRINCIPLE-AUDIT.md) (F-085) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
+6. [External deps catalogs](docs/DEPS-CATALOG.md) · [Target plugins](docs/TARGET-PLUGINS.md) (type-owned, Bazel-like; examples `10-target-plugins`, `11-metro-di`) · [Navigation abstraction](docs/NAVIGATION-ABSTRACTION.md) (presentation ports vs `navigationRes`, F-102) · [Call-site surface](docs/CALL-SITE-SURFACE.md) (Unit DSLs + flag inventory) · [Fleet tooling](docs/FLEET-TOOLING.md) (check/generate Gradle tasks + core APIs, F-084/F-088) · [Principle audit](docs/PRINCIPLE-AUDIT.md) (F-085) · [Compose](docs/COMPOSE.md) · [Environment](docs/ENV.md)
 7. [Plugin publish path](docs/PLUGIN-PUBLISH.md) — Portal metadata DSL + release notes (F-016)
 8. [Configuration performance](docs/CONFIGURATION-PERFORMANCE.md) — measure + hot-path guidance (F-017 / GH #106)
 9. [forma-core public API design](docs/forma-core-api.md) — extraction contract for types / restrictions / registry (F-020)

--- a/TICKETS.md
+++ b/TICKETS.md
@@ -142,14 +142,16 @@ worker (ops); `v2`→`master` (explicit git promote only). **F-094** stays `bloc
 | F-099 | done | Target-feature configuration options | GH **#126** — **done:** design `docs/TARGET-FEATURE-OPTIONS.md` + project-global `FormaFeatureFlags` on `androidProjectConfiguration` / `AndroidProjectSettings`; `depsIf`/`depsUnless`/`whenFlag` resolve at `applyDependencies` via pure `resolveFeatureFlags`; unit tests `:config`+`:deps`; docs PROJECT-CONFIGURATION / CALL-SITE / DEPS-CATALOG. Rejects call-site plugin shopping + binary-only flags. |
 | F-100 | done | Gradle project on buildscript classpath | GH **#111** — **done:** spike Gradle 9.6.1 — same-build `project()` on root buildscript **impossible** (`Project dependencies cannot be declared here`); includeBuild + GAV works. Shared `BuildscriptClasspath` classifier rejects `Project`/`ProjectDependency` with actionable error; accepts String GAV, catalog `plugin(...)`, File/FileCollection. Docs `BUILDSCRIPT-PROJECT-CLASSPATH.md` + PROJECT-CONFIGURATION/TARGET-PLUGINS/GETTING-STARTED. Unit tests `:config`; android+kmp wired. |
 | F-101 | done | Close `target(...)` deps API (audit) | GH **#56** **closable** — **done:** pure `ProjectPathForms.gradleProjectPathFromFormaTarget` + unit tests; `Project.target(String)` wired through it; docs DEPS-CATALOG §3 Project/target deps + CALL-SITE-SURFACE + GETTING-STARTED + README `target` example. Happy path = colon Forma paths + typesafe accessors; raw `project()` rejected; slash notation deferred #57. |
-| F-102 | todo | Navigation abstraction (sample + optional targets) | GH **#46** — reduce Jetpack Navigation codegen bleed across features. **Design first** (doc): presentation-layer nav ports vs Navigation Component; optional Forma nav targets only if type=rule fits. Prefer progressive example / sample refactor slice over new forever DSL. Large — split follow-ups if needed. |
+| F-102 | done | Navigation abstraction design | GH **#46** — **done (design):** [`docs/NAVIGATION-ABSTRACTION.md`](docs/NAVIGATION-ABSTRACTION.md) — Layer A presentation ports (no androidx.navigation in feature impl/VM) vs Layer B existing Path B `navigationRes` only; v1 = Jetpack behind root adapter; reject engine router DSL / plugin shopping / impl→impl / dual happy paths. Implement split: **F-111** sample, **F-112** progressive example. |
+| F-111 | todo | Sample navigation ports + root adapter | GH **#46** implement — apply F-102 design to `application/`: Navigator/destinations (or equiv) without Nav in feature `impl`/VM; adapter at composition root owns NavController + Safe Args; keep `navigationRes`; strip feature→`core/navigation/res` where practical. No Forma engine DSL. |
+| F-112 | todo | Progressive example: navigation ports | GH **#46** teach — `examples/android/12-navigation-ports` per F-102 §4.4; ladder + README; minimal graph; ports vs adapter vs `navigationRes`. Prefer before or with F-111. |
 | F-103 | todo | Hybrid targets example (flat dir / api+impl co-location) | GH **#44** — teaching example: simplified flat layout (api/impl/stub mental model, easy multi-module nav). May use includer layout + progressive example; align with F-084/F-088 fleet layout. No restore of `androidLibrary`. |
 | F-104 | todo | Hybrid configuration / stub targets for IDE sync | GH **#43** — stub targets + deps API so IDE sync can swap `impl`→`stub` (compileOnly/runtimeOnly pattern) via **one project-global flag**, not per-module hacks. Design+spike; depend on F-101/`target` APIs. Keep matrix truth. |
 
 ## P11 — Kotlin Multiplatform (Stepan 2026-07-25)
 
 Third Gradle platform on forma-core (`tools.forma.kmp`). **Design:** [`docs/KMP-TARGETS.md`](docs/KMP-TARGETS.md).
-**P11 v1 complete (F-105…F-110).** **F-100 / F-101 done.** Next board priority is **P10** top `todo` (**F-102**…) unless
+**P11 v1 complete (F-105…F-110).** **F-100…F-102 done** (F-102 = navigation design only). Next board priority is **P10** top `todo` (**F-111** sample nav ports, then **F-112** / **F-103**…) unless
 Stepan reprioritizes. v1 = **jvm + android** shared libraries only; type-owned MPP; **no** per-module
 target shopping; composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 
@@ -177,7 +179,7 @@ Keep for reference; do not start unless higher tickets done or user prioritizes:
 - ~~GH #77 transitiveDeps extension~~ → **F-096**
 - GH #54 Generate target structure from minimal config → **theme under F-084 / F-088**
 - ~~GH #51 Support build types~~ → **F-097**
-- ~~GH #46 New navigation system~~ → **F-102**
+- ~~GH #46 New navigation system~~ → **F-102** design done; implement **F-111** / **F-112**
 - ~~GH #44 Hybrid targets example~~ → **F-103**
 - ~~GH #43 Hybrid configuration example~~ → **F-104**
 - GH #36 Docs for external plugins → **P7 / F-070–F-073**

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -229,7 +229,7 @@ application/
 ├── core/
 │   ├── di/android-util     androidUtil
 │   ├── mvvm/ui-library     uiLibrary
-│   ├── navigation/res      androidRes
+│   ├── navigation/res      navigationRes (Path B; safe-args type-owned)
 │   ├── network/library     library (JVM)
 │   └── theme/{android-util,res}
 ├── common/
@@ -251,7 +251,9 @@ application/
 Wiring pattern:
 
 - Feature **api** = JVM Kotlin contracts (+ network/library etc.)
-- Feature **impl** = Android library + Dagger + navigation + viewbinding/res/widget
+- Feature **impl** = Android library + Dagger + viewbinding/res/widget (today also
+  Jetpack Navigation bleed — see [NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md);
+  F-111 moves Nav/Safe Args to a root adapter)
 - **binary** depends on root-app + all feature api/impl + shared core (explicit
   graph; not only transitive)
 - `packageName` aligned to path under `tools.forma.sample…` (F-014)
@@ -375,6 +377,7 @@ Suggested extraction order (tickets F-020…F-024):
 | Shared `library` suffix for JVM vs Android library | F-020 design: unique `TargetType.id`, shared suffix OK ([`forma-core-api.md`](forma-core-api.md) §7); optional rename later |
 | Plugin publish / Portal path | F-016 (`docs/PLUGIN-PUBLISH.md`; Portal org GH #133 is human) |
 | ~~Configuration-time cost (validators/deps/repos)~~ → [`docs/CONFIGURATION-PERFORMANCE.md`](CONFIGURATION-PERFORMANCE.md) | F-017 done |
+| Navigation tooling bleed into feature `impl` (GH #46) → design [`NAVIGATION-ABSTRACTION.md`](NAVIGATION-ABSTRACTION.md); implement F-111/F-112 | F-102 design done |
 
 ---
 
@@ -392,6 +395,7 @@ Suggested extraction order (tickets F-020…F-024):
 | Auto module discovery | `includer/` |
 | CI | `.github/workflows/main.yml` |
 | Sample structure | `application/feature/**`, `binary/` · [SAMPLE-APP.md](SAMPLE-APP.md); JVM: `jvm-application/` · [JVM-SAMPLE.md](JVM-SAMPLE.md) |
+| Navigation ports vs `navigationRes` | [NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md) (F-102 design; F-111/F-112 implement) |
 
 ---
 

--- a/docs/NAVIGATION-ABSTRACTION.md
+++ b/docs/NAVIGATION-ABSTRACTION.md
@@ -1,0 +1,307 @@
+# Navigation abstraction (F-102 / GH #46)
+
+**Status:** design shipped (this doc). Implementation is **not** a Forma engine
+feature — it is **sample architecture + progressive teaching**, with optional
+reuse of existing Path B `navigationRes` only where type=rule already fits.
+
+| Slice | Ticket | Scope |
+|-------|--------|--------|
+| Design (this doc) | **F-102** | Problem, layers A/B, v1 approach, rejects, ticket map |
+| Sample ports + root adapter | **F-111** | Gold-standard `application/` refactor |
+| Progressive example | **F-112** | `examples/android/12-navigation-ports` |
+| Optional type tweaks | only if evidence | No new forever router DSL in plugins |
+
+---
+
+## 1. Problem
+
+The gold-standard sample uses **Jetpack Navigation** with **Safe Args** codegen.
+That is a fine product choice for the APK. The failure mode is **bleed**: feature
+`impl` / ViewModels / shared UI helpers take **hard dependencies** on navigation
+APIs and generated symbols, so structure and presentation are glued to one tool.
+
+### Concrete bleed in `application/` today (GH #46)
+
+| Location | Leak |
+|----------|------|
+| `CharactersListFragment` | `findNavController().navigate(CharactersListFragmentDirections…)` — Safe Args `*Directions` + NavController in feature `impl` |
+| `HomeViewModel` (home `viewbinding`) | `NavController` listener + `core.navigation.library.R.id.*` graph destination ids |
+| `home/impl` bottom nav | `setupWithNavController(navGraphIds=…)` multi-backstack helper wired to graph R.ids |
+| Feature `impl` / `viewbinding` `build.gradle.kts` | `androidx.navigation` + `target(":core:navigation:res")` so codegen/R reach UI modules |
+| `common/extensions/android-util` | Multi-backstack `BottomNavigationView.setupWithNavController` — useful, but Nav-typed surface shared widely |
+
+In-code TODOs already name the gap:
+
+- *“Need abstract navigation layer here”* (`CharactersListFragment`)
+- *“Move out from here strong deps of navigation component”* (`HomeViewModel`, issue #46)
+
+### Why this hurts Forma structure
+
+1. **Feature `impl` becomes tool-shaped** — swapping Navigation Component,
+   Compose Navigation, or a router library rewrites every feature, not one adapter.
+2. **Codegen becomes a cross-feature API** — `*Directions` and graph `R.id`s are
+   not domain contracts; they couple modules to XML graph layout and safe-args packages.
+3. **Composition boundary blurs** — navigation wiring belongs next to the host
+   (`androidApp` / `androidBinary` / dedicated adapter), not deep in every feature.
+4. **Teaching risk** — if the sample’s happy path is raw `findNavController` in
+   `impl`, learners copy that into every module and ignore the flat graph.
+
+This ticket is **not** “replace Jetpack Navigation with a Forma-owned router.”
+It is **protect presentation and the module graph from navigation tooling**.
+
+---
+
+## 2. Alignment with Forma root principles
+
+Full axioms: [`VISION.md`](VISION.md). Consequences for navigation:
+
+| Principle | Navigation consequence |
+|-----------|------------------------|
+| **Bazel-like rules** | Safe-args / nav graph modules stay **type-owned** (`navigationRes`). Call sites = package + deps. No per-module plugin shopping. |
+| **One global way** | One presentation-port pattern for the sample (and the progressive example). One Path B type for nav graphs. Do not teach raw Nav *and* ports as dual happy paths. |
+| **Explicit structure + tooling** | Destinations and “who may navigate where” are declared as **app contracts** (sealed types / ports), not implied by whichever fragment imported `Directions`. |
+| **Composition only at roots** | Jetpack `NavController`, graph inflation, Safe Args execute **only** in composition-root or a dedicated adapter module depended on by the root — never `impl` → `impl` for “nav wiring.” |
+| **Closed dependency matrix** | No new `navImpl` / free-form edges unless a future ticket proves a matrix change. Default: ports live on existing roles (`api`, `androidUtil`, root). |
+| **External plugins type-owned** | Keep [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) Path B `navigationRes`. Never restore `.withPlugin` / free-form plugin id lists / `androidLibrary`. |
+
+**Forma plugins do not embed Cicerone, Compose Navigation, or a custom router
+framework.** Optional external libraries remain **app dependencies** behind the
+same ports if a product chooses them.
+
+---
+
+## 3. Two layers (do not conflate)
+
+### Layer A — Presentation-layer navigation ports (app architecture)
+
+**Owner:** the product / sample app, not `tools.forma` engine DSLs.
+
+**Goal:** feature `api` / `impl` / ViewModels express **intent** (“open character
+detail for id X”, “leave full-screen”, “back”) without importing:
+
+- `androidx.navigation.*`
+- Safe Args `*Directions` / `*Args`
+- Navigation graph `R.id` / `R.navigation`
+
+**Typical shapes (v1 — pick one style and stick to it in the sample):**
+
+```text
+feature api or thin shared androidUtil
+  └── Navigator (interface)  and/or  sealed AppDestination / feature events
+feature impl / ViewModel
+  └── emits destinations or one-way nav events (no NavController)
+composition root or navigation adapter module
+  └── implements Navigator: NavController + Safe Args + graph ids
+navigationRes (existing)
+  └── XML graphs + type-owned safe-args codegen (consumed only by adapter/root)
+```
+
+| Piece | Suggested home | Depends on androidx.navigation? |
+|-------|----------------|-----------------------------------|
+| `Navigator` / destination types / nav events | feature `api`, or small shared `androidUtil` / `api` used by features | **No** |
+| Feature UI + ViewModels | feature `impl` / `viewbinding` | **No** (after F-111) |
+| Adapter (`NavigatorImpl`, graph host, bottom-nav wiring) | `androidApp` / dedicated module next to root (e.g. `androidUtil` or root-owned impl) | **Yes** |
+| Nav graphs + Safe Args | `core/navigation/res` via **`navigationRes`** | plugin on **type**, not call-site shopping |
+
+**Dependency direction:**
+
+```text
+feature impl ──► feature api (ports) ──► (no nav library)
+androidApp / adapter ──► feature api + navigationRes + androidx.navigation
+androidBinary ──► androidApp + feature impls + …
+```
+
+Feature `impl` must **not** depend on `core/navigation/res` once ports land
+(unless a rare, documented exception — default is adapter-only).
+
+### Layer B — Optional Forma target / types
+
+**Only** when type=rule genuinely fits. Today that bar is already met by:
+
+| Existing | Role |
+|----------|------|
+| Path B **`navigationRes`** | Derived `androidRes` + type-owned `androidx.navigation.safeargs.kotlin` |
+| Safe Args on buildscript classpath | `extraPlugins` / catalog — jars only; apply is type-owned ([PROJECT-CONFIGURATION.md](PROJECT-CONFIGURATION.md)) |
+| Cache-friendly plugin line | **F-089** / GH #110 — keep `navigation-safe-args-gradle-plugin` on a line with relative `navigationFiles` sensitivity ([CONFIGURATION-PERFORMANCE.md](CONFIGURATION-PERFORMANCE.md)) |
+
+**Do not invent** in Forma plugins:
+
+- A forever DSL for routers, back stacks, or `BackTo(Class<Destination>)` engines
+- Built-in Cicerone (or any third-party navigator) integration
+- A new first-class `navImpl` / `navigationLibrary` target that bypasses the matrix
+  “because navigation is special”
+- Dual paths: plain `androidRes` + `.withPlugin(safe-args)` **and** `navigationRes`
+
+Optional future type work (only with evidence, separate ticket): e.g. document a
+second derived type if graphs must split by product flavor — still Path B, still
+no call-site plugin lists.
+
+---
+
+## 4. Recommended v1 approach (sample + progressive example)
+
+**Stay on Jetpack Navigation + Safe Args for the APK.** Abstract at the
+**presentation boundary**, not by forking a new navigation product inside Forma.
+
+### 4.1 Contracts (no AndroidX Navigation)
+
+Illustrative sketch (names flexible in F-111):
+
+```kotlin
+// e.g. feature/characters/list/api or shared navigation-api androidUtil
+sealed interface AppDestination {
+    data class CharacterDetail(val id: Long) : AppDestination
+    // …home tabs / favorite as needed — prefer feature-local sealed types
+    // composed at root if the app grows
+}
+
+interface Navigator {
+    fun navigate(to: AppDestination)
+    fun back()
+}
+```
+
+ViewModels expose **one-way events** (`SingleLiveData` / `SharedFlow` / existing
+MVVM helpers) carrying `AppDestination` or feature-specific nav events.
+Fragments/Activities **collect** and call `Navigator` — or the adapter observes
+events at the host. Either way, **no** `*Directions` in feature modules.
+
+Optional GH #46 idea (`BackTo` with `Class<Destination>`): fine as an **app-level**
+API on the port if the sample needs typed back-stack pops; implement with Nav
+APIs **only inside the adapter**. Do not promote it to a Forma plugin API.
+
+### 4.2 Adapter at the composition boundary
+
+- Implement `Navigator` where `NavController` is owned (activity / root nav host /
+  home host fragment coordinator).
+- Map `AppDestination` → Safe Args directions / `navigate(resId)` / deep links.
+- Keep multi-backstack `setupWithNavController` helpers in a module that **already**
+  may depend on Navigation (e.g. root or nav adapter `androidUtil`) — not in
+  feature ViewModels.
+- Replace `HomeViewModel`’s `NavController` + raw `R.id` set with either:
+  - destination **logical** ids / sealed “chrome mode” events from the adapter, or
+  - chrome state pushed in by the host after destination changes (adapter → VM).
+
+### 4.3 Graphs stay on `navigationRes`
+
+Unchanged happy path for **resources + codegen**:
+
+```kotlin
+// application/core/navigation/res/build.gradle.kts
+navigationRes(
+    packageName = "tools.forma.sample.core.navigation.library",
+    dependencies = deps(androidx.navigation),
+)
+```
+
+See [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) Path B and sample
+`build-dependencies` `NavigationRes.kt`. **F-089** cache notes remain the
+build-performance contract; abstraction work must not reintroduce absolute-path
+safe-args lines or call-site plugin apply.
+
+### 4.4 Progressive example shape (F-112 — implement later)
+
+`examples/android/12-navigation-ports/` (name locked here for the ladder):
+
+| Module role | Responsibility |
+|-------------|----------------|
+| `navigation-api` (`api` or `androidUtil`) | `Navigator` + sealed destinations — **zero** androidx.navigation |
+| `feature/*/impl` | UI emits destinations / events only |
+| `navigation-adapter` (`androidUtil` or root-local) | `Navigator` impl + optional tiny graph |
+| `core/nav/res` or `navigationRes` | XML + safe-args (Path B), depended on by **adapter/root only** |
+| `androidApp` / `androidBinary` | Composition: wire adapter + features |
+
+Keep the example **minimal** (one or two destinations), not a second Marvel app.
+Curriculum: add a row on [`PROGRESSIVE-EXAMPLES.md`](PROGRESSIVE-EXAMPLES.md) when
+F-112 lands (placeholder noted there after this design).
+
+### 4.5 External libraries (Cicerone, Compose Navigation, …)
+
+Documented pattern only:
+
+1. Ports stay the same (Layer A).
+2. Swap or dual-write the **adapter** implementation.
+3. Do **not** add Forma engine support or a second sample happy path that teaches
+   the library without ports.
+
+---
+
+## 5. Explicit reject list
+
+| Reject | Why |
+|--------|-----|
+| Per-module plugin lists / `.withPlugin(safe-args)` | Type-owned plugins only; dual happy path; F-081 removed chain API |
+| Restoring `androidLibrary` for “nav stuff” | Removed F-063; use role-specific targets |
+| `impl` → `impl` edges for graphs or navigators | Matrix + composition-at-roots |
+| Teaching raw `findNavController` / `*Directions` in feature `impl` as the **structural** happy path | Re-creates GH #46 bleed; ports are the happy path after F-111 |
+| Dual happy paths (ports **or** raw Nav in features “both fine”) | Violates one global way for the sample/docs |
+| Forever Forma DSL / built-in router framework in `plugins/` | Out of product scope; competes with app libraries; not type=rule |
+| Embedding Cicerone (or similar) inside Forma | Optional **app** dependency behind ports only |
+| New matrix type `navImpl` without a separate evidence-based ticket | Prefer existing `api` / `androidUtil` / root |
+| Changing validators “so features can depend on navigationRes freely” | Wrong layer; fix direction of deps via adapter |
+| Large greenfield navigation library as this ticket’s deliverable | Design + progressive/sample slices only |
+
+---
+
+## 6. Ticket map / follow-ups
+
+| ID | Status intent | Deliverable |
+|----|---------------|-------------|
+| **F-102** | **done** (design) | This document + cross-links + board split |
+| **F-111** | todo | Sample: presentation ports + adapter at composition root; strip Nav/Safe Args from feature `impl`/VM where practical; keep `navigationRes`; `application/` still green |
+| **F-112** | todo | Progressive example `examples/android/12-navigation-ports` + ladder/skill links |
+| F-102c (optional) | only if needed | Tiny type/docs tweak to `navigationRes` / TARGET-PLUGINS — **no** router engine |
+
+**Ordering:** F-111 may land before or after F-112; prefer **F-112 first** if the
+sample refactor is large (teach on a minimal graph, then migrate Marvel). Either
+order is fine as long as both follow this design.
+
+**Out of scope for the F-102 family:** hybrid targets (F-103), stub/IDE sync
+(F-104), KMP, Plugin Portal, matrix rewrites, engine DSL.
+
+### Definition of done (implement slices)
+
+**F-111**
+
+- [ ] Navigator / destinations (or equivalent) with **no** androidx.navigation in
+      feature contracts used by `impl`/VM
+- [ ] Adapter at root (or root-owned module) owns `NavController` + Safe Args
+- [ ] Feature modules no longer depend on `core/navigation/res` unless justified
+      in PROGRESS
+- [ ] Comments/TODOs for GH #46 in touched files resolved or narrowed
+- [ ] `application/` `./gradlew :binary:assembleDebug` (or full `build`) green on
+      real host — never invent green
+
+**F-112**
+
+- [ ] Example builds; README explains ports vs adapter vs `navigationRes`
+- [ ] `PROGRESSIVE-EXAMPLES.md` matrix row + examples README link
+- [ ] No `.withPlugin`; no `androidLibrary`
+
+---
+
+## 7. References
+
+| Doc / code | Why |
+|------------|-----|
+| GH **#46** | Original “abstract navigation layer” / strong Nav deps |
+| [`VISION.md`](VISION.md) | Root principles |
+| [`TARGET-PLUGINS.md`](TARGET-PLUGINS.md) | Path B `navigationRes`, no call-site plugins |
+| [`CONFIGURATION-PERFORMANCE.md`](CONFIGURATION-PERFORMANCE.md) | F-089 Safe Args task cache |
+| [`SAMPLE-APP.md`](SAMPLE-APP.md) | Gold-standard layout; nav graphs under `core/navigation/res` |
+| [`DEPENDENCY-MATRIX.md`](DEPENDENCY-MATRIX.md) | Closed edges — unchanged by this design |
+| [`PROGRESSIVE-EXAMPLES.md`](PROGRESSIVE-EXAMPLES.md) | Ladder; step 12 reserved for F-112 |
+| `application/core/navigation/res` | Live `navigationRes` call site |
+| `CharactersListFragment` / `HomeViewModel` | Bleed examples + TODOs |
+
+---
+
+## 8. Summary
+
+1. **Problem** = tooling/codegen bleed into features, not “missing Forma router.”
+2. **Layer A** = app presentation ports; features stay Nav-free.
+3. **Layer B** = keep **`navigationRes`** (+ F-089 cache discipline); no new engine DSL.
+4. **v1** = Jetpack Navigation behind an adapter at the composition root; teach via
+   progressive example + sample refactor (F-111 / F-112).
+5. **Reject** plugin shopping, impl→impl nav graphs, dual happy paths, and
+   Forma-owned forever navigation frameworks.

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,20 @@
 
 Newest entries first.
 
+## 2026-07-26 — F-102: Navigation abstraction design (GH #46)
+
+- **Ticket:** F-102 → `done` (design bar only). Implement follow-ups **F-111** (sample ports + root adapter), **F-112** (`examples/android/12-navigation-ports`).
+- **Branch:** `forma/F-102-navigation-abstraction` (from `origin/v2`)
+- **Docs:**
+  - Canonical [`docs/NAVIGATION-ABSTRACTION.md`](NAVIGATION-ABSTRACTION.md) — problem (sample bleed: `findNavController`, Safe Args `*Directions`, graph R.ids, multi-backstack helpers in feature impl/VM); Layer A presentation ports vs Layer B existing Path B `navigationRes` only; v1 = keep Jetpack Navigation behind composition-root adapter; reject engine router DSL / Cicerone-in-Forma / plugin shopping / impl→impl / dual happy paths / restoring `androidLibrary`; ticket map + DoD for F-111/F-112; refs F-089 cache + TARGET-PLUGINS
+  - Cross-links: README doc index; SAMPLE-APP; PROGRESSIVE-EXAMPLES (row 12 reserved); ARCHITECTURE (tree + follow-ups + quick ref); TARGET-PLUGINS Path B blurb
+- **Board:** TICKETS F-102 `done`; added F-111 + F-112 `todo` after F-102; P11 header + backlog GH #46 note
+- **Code:** none (docs + board only — no sample rewrite, no plugin DSL)
+- **Verify:** docs-only slice; no Gradle run required. Spot-check: design doc present; F-111/F-112 on board; no `plugins/` engine changes
+- **Skills/modes:** Grok Build implement phase (design-first); `/check-work` after commit
+- **Not in this slice:** F-111/F-112 code; matrix/validator changes; Forma router framework; F-103/F-104
+- **Next step:** F-111 or F-112 per NAVIGATION-ABSTRACTION §6 (prefer F-112 first if sample refactor is large)
+
 ## 2026-07-26 — F-101: Close `target(...)` deps API audit (GH #56)
 
 - **Ticket:** F-101 → `done` (GH #56 closable)

--- a/docs/PROGRESSIVE-EXAMPLES.md
+++ b/docs/PROGRESSIVE-EXAMPLES.md
@@ -33,6 +33,7 @@ narrative tutorials when you want a **minimal buildable project per concept**.
 | `androidTestUtil` | 09 | — | — | forma-android-targets |
 | Type-owned target plugins (`navigationRes` Path B) | 10 | — | — | forma-target-plugins |
 | Metro DI (`metroImpl` / `metroApp`, Path A on impl/app) | 11 | — | — | forma-target-plugins |
+| Navigation ports (presentation ports + adapter; Jetpack behind root) | **12** (F-112 todo) | — | — | — (design: [NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md)) |
 | `kmpLibrary` + `kmpProjectConfiguration` | — | — | 01 | forma-kmp-targets |
 | JVM/Android → `kmp.*` consumer edge | — | — | 01 (JVM binary) | forma-kmp-targets |
 | Fleet check/generate/migrate (`tools.forma.core.fleet`) | docs | docs | — | forma-fleet-tooling |
@@ -56,5 +57,8 @@ network) live in `application/` and are documented in SAMPLE-APP / GETTING-START
 Metro as an alternate compile-time DI stack is taught in
 [`examples/android/11-metro-di`](../examples/android/11-metro-di) (type-owned plugin;
 not a second sample-app rewrite).
+**Navigation ports** (keep Jetpack/Safe Args out of feature `impl`) are designed in
+[NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md); ladder step **12** and sample
+refactor are **F-112** / **F-111** (not shipped in the F-102 design slice).
 Sample-scale typed `build-dependencies/` catalogs are **advanced**, not a second
 default (see [DEPS-CATALOG.md](DEPS-CATALOG.md)).

--- a/docs/SAMPLE-APP.md
+++ b/docs/SAMPLE-APP.md
@@ -123,10 +123,16 @@ build JDK **21** (app language level unchanged). See [ENV.md](ENV.md),
 Not in scope for F-014: full navigation redesign (GH #46), publish path (F-016).
 Configuration-time performance: [CONFIGURATION-PERFORMANCE.md](CONFIGURATION-PERFORMANCE.md) (F-017).
 
+**Navigation abstraction (F-102 / GH #46):** design is in
+[NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md) — presentation-layer ports
+so feature `impl`/ViewModels do not take Jetpack Navigation / Safe Args codegen;
+graphs stay on `navigationRes`. Sample refactor = **F-111**; progressive example
+= **F-112**. This gold-standard tree still shows today’s bleed until F-111 lands.
+
 ## Type-owned plugins (navigation)
 
 `core/navigation/res` uses Path B **`navigationRes(...)`** (defined in
 `build-dependencies/.../NavigationRes.kt`), not plain `androidRes` + `.withPlugin`.
 Safe-args is owned by the derived type and auto-applies. See
-[TARGET-PLUGINS.md](TARGET-PLUGINS.md) and progressive example
-`examples/android/10-target-plugins/`.
+[TARGET-PLUGINS.md](TARGET-PLUGINS.md), [NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md)
+(Layer B), and progressive example `examples/android/10-target-plugins/`.

--- a/docs/TARGET-PLUGINS.md
+++ b/docs/TARGET-PLUGINS.md
@@ -201,6 +201,11 @@ No `.withPlugin`, no `pluginConfig = pluginConfig(binding)`.
 (sample **2.9.8**). See [`CONFIGURATION-PERFORMANCE.md`](CONFIGURATION-PERFORMANCE.md)
 § Navigation Safe Args task cache — do not paper over with call-site plugin APIs.
 
+**Presentation vs graphs (F-102 / GH #46):** `navigationRes` owns **graphs +
+safe-args apply**. Keeping Jetpack Navigation / `*Directions` out of feature
+`impl` is **app architecture** (ports + root adapter), not a new Forma router
+DSL — see [`NAVIGATION-ABSTRACTION.md`](NAVIGATION-ABSTRACTION.md).
+
 ---
 
 ## 5. Plugin config = rule attributes (uniform, optional)


### PR DESCRIPTION
## Summary
Design-first slice for **F-102** / GH #46 — protect presentation and the module graph from Jetpack Navigation / Safe Args bleed.

- Canonical design: `docs/NAVIGATION-ABSTRACTION.md`
  - Layer **A**: presentation ports (no `androidx.navigation` in feature `impl`/VM)
  - Layer **B**: keep existing Path B `navigationRes` only — **no** Forma engine router DSL
  - v1: Jetpack behind composition-root adapter; progressive example shape `12-navigation-ports`
  - Explicit reject list (plugin shopping, impl→impl, dual happy paths, `androidLibrary`, forever DSL)
- Cross-links: README, SAMPLE-APP, PROGRESSIVE-EXAMPLES, ARCHITECTURE, TARGET-PLUGINS
- Board: F-102 → `done` (design); **F-111** sample ports + **F-112** progressive example as `todo`
- Docs/board only — no plugin/engine or sample code rewrite

## Test plan
- [x] Docs-only review against VISION axioms + GH #46
- [x] `/check-work` PASS (Grok Build full)
- [ ] CI docs/no-op green on merge