### PR TITLE
F-111: sample navigation ports + root adapter

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -143,7 +143,7 @@ worker (ops); `v2`→`master` (explicit git promote only). **F-094** stays `bloc
 | F-100 | done | Gradle project on buildscript classpath | GH **#111** — **done:** spike Gradle 9.6.1 — same-build `project()` on root buildscript **impossible** (`Project dependencies cannot be declared here`); includeBuild + GAV works. Shared `BuildscriptClasspath` classifier rejects `Project`/`ProjectDependency` with actionable error; accepts String GAV, catalog `plugin(...)`, File/FileCollection. Docs `BUILDSCRIPT-PROJECT-CLASSPATH.md` + PROJECT-CONFIGURATION/TARGET-PLUGINS/GETTING-STARTED. Unit tests `:config`; android+kmp wired. |
 | F-101 | done | Close `target(...)` deps API (audit) | GH **#56** **closable** — **done:** pure `ProjectPathForms.gradleProjectPathFromFormaTarget` + unit tests; `Project.target(String)` wired through it; docs DEPS-CATALOG §3 Project/target deps + CALL-SITE-SURFACE + GETTING-STARTED + README `target` example. Happy path = colon Forma paths + typesafe accessors; raw `project()` rejected; slash notation deferred #57. |
 | F-102 | done | Navigation abstraction design | GH **#46** — **done (design):** [`docs/NAVIGATION-ABSTRACTION.md`](docs/NAVIGATION-ABSTRACTION.md) — Layer A presentation ports (no androidx.navigation in feature impl/VM) vs Layer B existing Path B `navigationRes` only; v1 = Jetpack behind root adapter; reject engine router DSL / plugin shopping / impl→impl / dual happy paths. Implement split: **F-111** sample, **F-112** progressive example. |
-| F-111 | todo | Sample navigation ports + root adapter | GH **#46** implement — apply F-102 design to `application/`: Navigator/destinations (or equiv) without Nav in feature `impl`/VM; adapter at composition root owns NavController + Safe Args; keep `navigationRes`; strip feature→`core/navigation/res` where practical. No Forma engine DSL. |
+| F-111 | done | Sample navigation ports + root adapter | GH **#46** implement — `core/navigation/api` ports + `root-app` Jetpack adapter + `core/navigation/android-util` home-shell binder; feature `impl`/VM Nav-free; `navigationRes` kept; feature→`core/navigation/res` stripped. |
 | F-112 | done | Progressive example: navigation ports | GH **#46** teach — `examples/android/12-navigation-ports` per F-102 §4.4; ladder + README; minimal graph; ports vs adapter vs `navigationRes`. Prefer before or with F-111. |
 | F-103 | todo | Hybrid targets example (flat dir / api+impl co-location) | GH **#44** — teaching example: simplified flat layout (api/impl/stub mental model, easy multi-module nav). May use includer layout + progressive example; align with F-084/F-088 fleet layout. No restore of `androidLibrary`. |
 | F-104 | todo | Hybrid configuration / stub targets for IDE sync | GH **#43** — stub targets + deps API so IDE sync can swap `impl`→`stub` (compileOnly/runtimeOnly pattern) via **one project-global flag**, not per-module hacks. Design+spike; depend on F-101/`target` APIs. Keep matrix truth. |
@@ -153,7 +153,7 @@ worker (ops); `v2`→`master` (explicit git promote only). **F-094** stays `bloc
 ## P11 — Kotlin Multiplatform (Stepan 2026-07-25)
 
 Third Gradle platform on forma-core (`tools.forma.kmp`). **Design:** [`docs/KMP-TARGETS.md`](docs/KMP-TARGETS.md).
-**P11 v1 complete (F-105…F-110).** **F-100…F-102 done** (F-102 = navigation design only). **F-112 done** (progressive nav ports). Next board priority is **P10** top `todo` (**F-111** sample nav ports, then **F-103**…) unless
+**P11 v1 complete (F-105…F-110).** **F-100…F-102 done** (F-102 = navigation design only). **F-111 + F-112 done** (sample + progressive nav ports). Next board priority is **P10** top `todo` (**F-103** hybrid targets, then **F-104**…) unless
 Stepan reprioritizes. v1 = **jvm + android** shared libraries only; type-owned MPP; **no** per-module
 target shopping; composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 
@@ -181,7 +181,7 @@ Keep for reference; do not start unless higher tickets done or user prioritizes:
 - ~~GH #77 transitiveDeps extension~~ → **F-096**
 - GH #54 Generate target structure from minimal config → **theme under F-084 / F-088**
 - ~~GH #51 Support build types~~ → **F-097**
-- ~~GH #46 New navigation system~~ → **F-102** design done; implement **F-111** / **F-112**
+- ~~GH #46 New navigation system~~ → **F-102** design + **F-111** sample + **F-112** example **done**
 - ~~GH #44 Hybrid targets example~~ → **F-103**
 - ~~GH #43 Hybrid configuration example~~ → **F-104**
 - GH #36 Docs for external plugins → **P7 / F-070–F-073**

--- a/application/common/extensions/android-util/build.gradle.kts
+++ b/application/common/extensions/android-util/build.gradle.kts
@@ -8,7 +8,6 @@ androidUtil(
             androidx.constraintlayout,
             androidx.fragment,
             androidx.viewmodel,
-            androidx.navigation,
             androidx.recyclerview,
             androidx.paging,
             google.material,

--- a/application/core/navigation/android-util/build.gradle.kts
+++ b/application/core/navigation/android-util/build.gradle.kts
@@ -1,0 +1,16 @@
+// Nav-aware host helpers consumed by composition-root adapter / home shell only.
+// Feature happy path uses core/navigation/api ports — not this module for destinations.
+androidUtil(
+    packageName = "tools.forma.sample.core.navigation.android.util",
+    owner = Teams.core,
+    dependencies = deps(
+        androidx.core_ktx,
+        androidx.fragment,
+        androidx.navigation,
+        androidx.appcompat,
+        androidx.viewmodel,
+        google.material,
+    ) + deps(
+        target(":core:navigation:res"),
+    ),
+)

--- a/application/core/navigation/android-util/src/main/java/tools/forma/sample/core/navigation/android/util/HomeShellNavigation.kt
+++ b/application/core/navigation/android-util/src/main/java/tools/forma/sample/core/navigation/android/util/HomeShellNavigation.kt
@@ -1,0 +1,41 @@
+package tools.forma.sample.core.navigation.android.util
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.LifecycleOwner
+import com.google.android.material.bottomnavigation.BottomNavigationView
+
+/**
+ * Nav-aware host surface for the home composition shell (multi-backstack bottom nav).
+ *
+ * HomeFragment depends on this port instead of graph R.ids / NavController directly.
+ * Jetpack implementation lives at the composition root (`root-app`).
+ *
+ * Kept free of Layer A `api` ports so this `androidUtil` stays matrix-valid
+ * (`androidUtil` ↛ `api`). Chrome is reported as a boolean; home maps it to
+ * [tools.forma.sample.core.navigation.api.HomeChromeMode] / HomeViewState.
+ */
+interface HomeShellNavigation {
+
+    /**
+     * Wire multi-backstack bottom navigation + action bar.
+     *
+     * @param onNavigationScreen true when the active destination is a tab root
+     *   (show app bar + bottom nav); false for full-screen destinations.
+     */
+    fun bind(
+        activity: AppCompatActivity,
+        bottomNavigationView: BottomNavigationView,
+        fragmentManager: FragmentManager,
+        containerId: Int,
+        intent: Intent,
+        lifecycleOwner: LifecycleOwner,
+        onNavigationScreen: (Boolean) -> Unit,
+    )
+}
+
+/** Application exposes the home-shell binder like other feature providers. */
+interface HomeShellNavigationProvider {
+    fun getHomeShellNavigation(): HomeShellNavigation
+}

--- a/application/core/navigation/android-util/src/main/java/tools/forma/sample/core/navigation/android/util/NavigationExtensions.kt
+++ b/application/core/navigation/android-util/src/main/java/tools/forma/sample/core/navigation/android/util/NavigationExtensions.kt
@@ -14,7 +14,7 @@
  * limitations under the License.
  */
 
-package tools.forma.sample.common.extensions.android.util
+package tools.forma.sample.core.navigation.android.util
 
 import android.content.Intent
 import android.util.SparseArray

--- a/application/core/navigation/api/build.gradle.kts
+++ b/application/core/navigation/api/build.gradle.kts
@@ -1,0 +1,5 @@
+// Layer A presentation ports — zero androidx.navigation (F-102 / F-111).
+api(
+    packageName = "tools.forma.sample.core.navigation.api",
+    owner = Teams.core,
+)

--- a/application/core/navigation/api/src/main/java/tools/forma/sample/core/navigation/api/AppDestination.kt
+++ b/application/core/navigation/api/src/main/java/tools/forma/sample/core/navigation/api/AppDestination.kt
@@ -1,0 +1,17 @@
+package tools.forma.sample.core.navigation.api
+
+/**
+ * Presentation-layer destinations. Feature `impl` emits these; only the composition-root
+ * adapter maps them onto Jetpack Navigation / Safe Args.
+ */
+sealed interface AppDestination {
+    data class CharacterDetail(val characterId: Long) : AppDestination
+}
+
+/**
+ * Bundle argument keys for destinations. Must match `android:name` on nav-graph
+ * `<argument>` entries. Features read plain Bundle values; they never import Safe Args `*Args`.
+ */
+object CharacterDetailArgs {
+    const val CHARACTER_ID = "character_id"
+}

--- a/application/core/navigation/api/src/main/java/tools/forma/sample/core/navigation/api/HomeChromeMode.kt
+++ b/application/core/navigation/api/src/main/java/tools/forma/sample/core/navigation/api/HomeChromeMode.kt
@@ -1,0 +1,13 @@
+package tools.forma.sample.core.navigation.api
+
+/**
+ * Logical home-shell chrome mode. Pushed from the composition-root adapter when the
+ * active destination changes — feature ViewModels never see NavController or graph R.ids.
+ */
+enum class HomeChromeMode {
+    /** Bottom nav + app bar visible (tab roots). */
+    NavigationScreen,
+
+    /** Full-screen content (e.g. character detail). */
+    FullScreen,
+}

--- a/application/core/navigation/api/src/main/java/tools/forma/sample/core/navigation/api/Navigator.kt
+++ b/application/core/navigation/api/src/main/java/tools/forma/sample/core/navigation/api/Navigator.kt
@@ -1,0 +1,20 @@
+package tools.forma.sample.core.navigation.api
+
+/**
+ * Navigation port used by feature UI. Implementations live at the composition root
+ * (see root-app [tools.forma.sample.root.library.navigation.JetpackNavigator]) —
+ * never inside feature `impl`.
+ */
+interface Navigator {
+    fun navigate(to: AppDestination)
+    fun back()
+}
+
+/**
+ * Application (or activity) exposes the port so feature fragments can resolve it
+ * without depending on androidx.navigation. Sample uses Application + [requireProvider]
+ * pattern already established for other feature providers.
+ */
+interface NavigatorProvider {
+    fun getNavigator(): Navigator
+}

--- a/application/feature/characters/detail/impl/build.gradle.kts
+++ b/application/feature/characters/detail/impl/build.gradle.kts
@@ -4,7 +4,6 @@ impl(
         androidx.core_ktx,
         androidx.appcompat,
         androidx.constraintlayout,
-        androidx.navigation,
         androidx.viewmodel,
         androidx.recyclerview,
         androidx.swiperefreshlayout,
@@ -27,7 +26,7 @@ impl(
         target(":core:theme:android-util"),
         target(":core:mvvm:ui-library"),
         target(":core:network:library"),
-        target(":core:navigation:res"),
+        target(":core:navigation:api"),
 
         target(":common:util"),
         target(":common:extensions:android-util"),

--- a/application/feature/characters/detail/impl/src/main/java/tools/forma/sample/feature/characters/detail/impl/ui/CharacterDetailFragment.kt
+++ b/application/feature/characters/detail/impl/src/main/java/tools/forma/sample/feature/characters/detail/impl/ui/CharacterDetailFragment.kt
@@ -19,8 +19,6 @@ package tools.forma.sample.feature.characters.detail.impl.ui
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
-import androidx.navigation.fragment.findNavController
-import androidx.navigation.fragment.navArgs
 import by.kirich1409.viewbindingdelegate.viewBinding
 import com.google.android.material.snackbar.Snackbar
 import tools.forma.sample.common.extensions.android.util.loadImage
@@ -28,6 +26,8 @@ import tools.forma.sample.common.extensions.android.util.observe
 import tools.forma.sample.common.progressbar.viewbinding.ProgressBarDialog
 import tools.forma.sample.core.mvvm.library.ui.BaseViewBindingFragment
 import tools.forma.sample.core.mvvm.library.viewModels
+import tools.forma.sample.core.navigation.api.CharacterDetailArgs
+import tools.forma.sample.core.navigation.api.NavigatorProvider
 import tools.forma.sample.feature.characters.core.api.di.CharactersCoreFeatureProvider
 import tools.forma.sample.feature.characters.core.api.domain.model.ICharacter
 import tools.forma.sample.feature.characters.detail.api.presentation.ICharacterDetailViewState
@@ -46,8 +46,6 @@ class CharacterDetailFragment : BaseViewBindingFragment(
     private val viewModel: CharacterDetailViewModel by viewModels()
     private val viewBinding: FragmentCharacterDetailBinding by viewBinding(FragmentCharacterDetailBinding::bind)
 
-    private val args: CharacterDetailFragmentArgs by navArgs()
-
     private lateinit var progressDialog: ProgressBarDialog
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
@@ -57,7 +55,8 @@ class CharacterDetailFragment : BaseViewBindingFragment(
 
         observe(viewModel.data, ::onViewDataChange)
         observe(viewModel.state, ::onViewStateChange)
-        viewModel.loadCharacterDetail(args.characterId)
+        val characterId = requireArguments().getLong(CharacterDetailArgs.CHARACTER_ID)
+        viewModel.loadCharacterDetail(characterId)
     }
 
     override fun onInitDependencyInjection() {
@@ -101,9 +100,7 @@ class CharacterDetailFragment : BaseViewBindingFragment(
                     Snackbar.LENGTH_LONG
                 ).show()
             is CharacterDetailViewState.Dismiss ->
-                // TODO https://github.com/formatools/forma/issues/46
-                // Need abstract navigation layer here
-                findNavController().navigateUp()
+                requireProvider(NavigatorProvider::class).getNavigator().back()
             else -> progressDialog.dismiss()
         }
     }

--- a/application/feature/characters/favorite/impl/build.gradle.kts
+++ b/application/feature/characters/favorite/impl/build.gradle.kts
@@ -4,7 +4,6 @@ impl(
         androidx.core_ktx,
         androidx.appcompat,
         androidx.constraintlayout,
-        androidx.navigation,
         androidx.viewmodel,
         androidx.recyclerview,
         androidx.swiperefreshlayout,
@@ -27,7 +26,6 @@ impl(
         target(":core:theme:android-util"),
         target(":core:mvvm:ui-library"),
         target(":core:network:library"),
-        target(":core:navigation:res"),
 
         target(":common:util"),
         target(":common:extensions:android-util"),

--- a/application/feature/characters/favorite/viewbinding/build.gradle.kts
+++ b/application/feature/characters/favorite/viewbinding/build.gradle.kts
@@ -2,7 +2,6 @@ viewBinding(
     packageName = "tools.forma.sample.feature.characters.favorite.viewbinding",
     dependencies = deps(
         google.material,
-        androidx.navigation,
         androidx.appcompat,
         androidx.constraintlayout,
     ) + deps(
@@ -10,7 +9,6 @@ viewBinding(
         target(":feature:characters:favorite:api"),
         target(":feature:characters:favorite:res"),
 
-        target(":core:navigation:res"),
         target(":core:mvvm:ui-library"),
         target(":core:theme:res")
     )

--- a/application/feature/characters/list/impl/build.gradle.kts
+++ b/application/feature/characters/list/impl/build.gradle.kts
@@ -5,7 +5,6 @@ impl(
             androidx.core_ktx,
             androidx.appcompat,
             androidx.constraintlayout,
-            androidx.navigation,
             androidx.viewmodel,
             androidx.recyclerview,
             androidx.swiperefreshlayout,
@@ -25,7 +24,7 @@ impl(
                 target(":core:theme:android-util"),
                 target(":core:mvvm:ui-library"),
                 target(":core:network:library"),
-                target(":core:navigation:res"),
+                target(":core:navigation:api"),
                 target(":common:util"),
                 target(":common:extensions:android-util"),
                 target(":common:recyclerview:widget")

--- a/application/feature/characters/list/impl/src/main/java/tools/forma/sample/feature/characters/list/impl/ui/CharactersListFragment.kt
+++ b/application/feature/characters/list/impl/src/main/java/tools/forma/sample/feature/characters/list/impl/ui/CharactersListFragment.kt
@@ -19,7 +19,6 @@ package tools.forma.sample.feature.characters.list.impl.ui
 import android.os.Bundle
 import android.view.View
 import androidx.core.view.isVisible
-import androidx.navigation.fragment.findNavController
 import androidx.paging.PagedList
 import by.kirich1409.viewbindingdelegate.viewBinding
 import tools.forma.sample.common.extensions.android.util.gridLayoutManager
@@ -27,6 +26,8 @@ import tools.forma.sample.common.extensions.android.util.observe
 import tools.forma.sample.common.recyclerview.widget.RecyclerViewItemDecoration
 import tools.forma.sample.core.mvvm.library.ui.BaseViewBindingFragment
 import tools.forma.sample.core.mvvm.library.viewModels
+import tools.forma.sample.core.navigation.api.AppDestination
+import tools.forma.sample.core.navigation.api.NavigatorProvider
 import tools.forma.sample.feature.characters.core.api.di.CharactersCoreFeatureProvider
 import tools.forma.sample.feature.characters.core.api.domain.model.ICharacter
 import tools.forma.sample.feature.characters.list.viewbinding.databinding.FragmentCharactersListBinding
@@ -105,13 +106,10 @@ class CharactersListFragment : BaseViewBindingFragment(
 
     private fun onViewEvent(viewEvent: ICharactersListViewEvent) {
         when (viewEvent) {
-            // TODO https://github.com/formatools/forma/issues/46
-            // Need abstract navigation layer here
             is CharactersListViewEvent.OpenCharacterDetail ->
-                findNavController().navigate(
-                    CharactersListFragmentDirections
-                        .actionCharactersListFragmentToCharacterDetailFragment(viewEvent.id)
-                )
+                requireProvider(NavigatorProvider::class)
+                    .getNavigator()
+                    .navigate(AppDestination.CharacterDetail(characterId = viewEvent.id))
         }
     }
 }

--- a/application/feature/home/impl/build.gradle.kts
+++ b/application/feature/home/impl/build.gradle.kts
@@ -5,7 +5,6 @@ impl(
             androidx.core_ktx,
             androidx.appcompat,
             androidx.constraintlayout,
-            androidx.navigation,
             google.material,
             google.dagger,
             viewbinding.viewpropertydelegate
@@ -19,7 +18,8 @@ impl(
                 target(":core:di:android-util"),
                 target(":core:theme:android-util"),
                 target(":core:mvvm:ui-library"),
-                target(":core:navigation:res"),
+                target(":core:navigation:api"),
+                target(":core:navigation:android-util"),
                 target(":common:extensions:android-util"),
             )
 )

--- a/application/feature/home/impl/src/main/java/tools/forma/sample/feature/home/impl/ui/HomeFragment.kt
+++ b/application/feature/home/impl/src/main/java/tools/forma/sample/feature/home/impl/ui/HomeFragment.kt
@@ -23,14 +23,13 @@ import android.view.MenuInflater
 import android.view.View
 import android.widget.Toast
 import androidx.core.view.isVisible
-import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
 import by.kirich1409.viewbindingdelegate.viewBinding
-import tools.forma.sample.common.extensions.android.util.setupWithNavController
 import tools.forma.sample.core.mvvm.library.ui.BaseViewBindingFragment
 import tools.forma.sample.core.mvvm.library.viewModels
+import tools.forma.sample.core.navigation.android.util.HomeShellNavigationProvider
+import tools.forma.sample.core.navigation.api.HomeChromeMode
 import tools.forma.sample.core.theme.android.util.ThemeUtils
 import tools.forma.sample.core.theme.android.util.di.ThemeComponentProvider
-import tools.forma.sample.feature.home.impl.R
 import tools.forma.sample.feature.home.impl.di.DaggerHomeComponent
 import tools.forma.sample.feature.home.viewbinding.databinding.FragmentHomeBinding
 import tools.forma.sample.feature.home.viewbinding.ui.HomeViewModel
@@ -39,18 +38,19 @@ import javax.inject.Inject
 
 private const val DELAY_TO_APPLY_THEME = 1000L
 
-class HomeFragment : BaseViewBindingFragment(tools.forma.sample.feature.home.viewbinding.R.layout.fragment_home) {
+/**
+ * Home composition shell. Bottom-nav multi-backstack + graph ids live in the
+ * root-owned [tools.forma.sample.root.library.navigation.JetpackHomeShellNavigation]
+ * adapter; this fragment only binds via [HomeShellNavigationProvider].
+ */
+class HomeFragment :
+    BaseViewBindingFragment(tools.forma.sample.feature.home.viewbinding.R.layout.fragment_home) {
 
     @Inject
     lateinit var themeUtils: ThemeUtils
 
     private val viewModel: HomeViewModel by viewModels()
     private val viewBinding: FragmentHomeBinding by viewBinding(FragmentHomeBinding::bind)
-
-    private val navGraphIds = listOf(
-        tools.forma.sample.core.navigation.library.R.navigation.navigation_characters_list_graph,
-        tools.forma.sample.core.navigation.library.R.navigation.navigation_character_favorite_graph
-    )
 
     override fun onViewCreated(view: View, savedInstanceState: Bundle?) {
         super.onViewCreated(view, savedInstanceState)
@@ -83,13 +83,18 @@ class HomeFragment : BaseViewBindingFragment(tools.forma.sample.feature.home.vie
             setOnMenuItemClickListener {
                 try {
                     // Correct way to take app version code and version name, instead of BuildConfig
-                    val packageInfo = requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
+                    val packageInfo =
+                        requireContext().packageManager.getPackageInfo(requireContext().packageName, 0)
                     val versionName = packageInfo.versionName
                     val versionCode = packageInfo.versionCode
                     Toast
                         .makeText(
                             requireContext(),
-                            getString(tools.forma.sample.feature.home.res.R.string.home_app_info_template, versionName, versionCode),
+                            getString(
+                                tools.forma.sample.feature.home.res.R.string.home_app_info_template,
+                                versionName,
+                                versionCode
+                            ),
                             Toast.LENGTH_LONG
                         )
                         .show()
@@ -123,18 +128,24 @@ class HomeFragment : BaseViewBindingFragment(tools.forma.sample.feature.home.vie
     }
 
     private fun setupBottomNavigationBar() {
-        // TODO https://github.com/formatools/forma/issues/46
-        // Need abstract navigation layer here
-        val navController = viewBinding.bottomNavigation.setupWithNavController(
-            navGraphIds = navGraphIds,
-            fragmentManager = childFragmentManager,
-            containerId = tools.forma.sample.feature.home.viewbinding.R.id.nav_host_container,
-            intent = requireActivity().intent
-        )
-
-        navController.observe(viewLifecycleOwner) {
-            viewModel.navigationControllerChanged(it)
-            setupActionBarWithNavController(requireCompatActivity(), it)
-        }
+        requireProvider(HomeShellNavigationProvider::class)
+            .getHomeShellNavigation()
+            .bind(
+                activity = requireCompatActivity(),
+                bottomNavigationView = viewBinding.bottomNavigation,
+                fragmentManager = childFragmentManager,
+                containerId = tools.forma.sample.feature.home.viewbinding.R.id.nav_host_container,
+                intent = requireActivity().intent,
+                lifecycleOwner = viewLifecycleOwner,
+                onNavigationScreen = { isNavigationScreen ->
+                    viewModel.onChromeModeChanged(
+                        if (isNavigationScreen) {
+                            HomeChromeMode.NavigationScreen
+                        } else {
+                            HomeChromeMode.FullScreen
+                        }
+                    )
+                },
+            )
     }
 }

--- a/application/feature/home/viewbinding/build.gradle.kts
+++ b/application/feature/home/viewbinding/build.gradle.kts
@@ -3,11 +3,10 @@ viewBinding(
     dependencies = deps(
         google.inject,
         google.material,
-        androidx.navigation,
         androidx.appcompat,
         androidx.constraintlayout
     ) + deps(
-        target(":core:navigation:res"),
+        target(":core:navigation:api"),
         target(":core:mvvm:ui-library"),
         target(":core:theme:res"),
         target(":feature:home:res"),

--- a/application/feature/home/viewbinding/src/main/java/tools/forma/sample/feature/home/viewbinding/ui/HomeViewModel.kt
+++ b/application/feature/home/viewbinding/src/main/java/tools/forma/sample/feature/home/viewbinding/ui/HomeViewModel.kt
@@ -19,31 +19,25 @@ package tools.forma.sample.feature.home.viewbinding.ui
 import androidx.lifecycle.LiveData
 import androidx.lifecycle.MutableLiveData
 import androidx.lifecycle.ViewModel
-import androidx.navigation.NavController
-import tools.forma.sample.feature.home.viewbinding.R
-
+import tools.forma.sample.core.navigation.api.HomeChromeMode
 import javax.inject.Inject
 
-// TODO https://github.com/formatools/forma/issues/46
-// Move out from here strong deps of navigation component
-val NAV_FRAGMENTS_ID = setOf(
-    tools.forma.sample.core.navigation.library.R.id.characters_list_fragment,
-    tools.forma.sample.core.navigation.library.R.id.character_favorite_fragment
-)
-
+/**
+ * Home chrome state only. Destination / NavController wiring lives in the
+ * composition-root adapter (F-111 / GH #46).
+ */
 class HomeViewModel @Inject constructor() : ViewModel() {
 
     private val _state = MutableLiveData<HomeViewState>()
     val state: LiveData<HomeViewState>
         get() = _state
 
-    fun navigationControllerChanged(navController: NavController) {
-        navController.addOnDestinationChangedListener { _, destination, _ ->
-            if (NAV_FRAGMENTS_ID.contains(destination.id)) {
-                _state.postValue(HomeViewState.NavigationScreen)
-            } else {
-                _state.postValue(HomeViewState.FullScreen)
+    fun onChromeModeChanged(mode: HomeChromeMode) {
+        _state.postValue(
+            when (mode) {
+                HomeChromeMode.NavigationScreen -> HomeViewState.NavigationScreen
+                HomeChromeMode.FullScreen -> HomeViewState.FullScreen
             }
-        }
+        )
     }
 }

--- a/application/root-app/build.gradle.kts
+++ b/application/root-app/build.gradle.kts
@@ -21,6 +21,8 @@ androidApp(
                 target(":feature:characters:favorite:api"),
                 target(":feature:characters:favorite:impl"),
                 target(":core:di:android-util"),
+                target(":core:navigation:api"),
+                target(":core:navigation:android-util"),
                 target(":core:navigation:res"),
                 target(":core:theme:android-util"),
                 target(":core:network:library"),

--- a/application/root-app/src/main/java/tools/forma/sample/root/library/SampleApp.kt
+++ b/application/root-app/src/main/java/tools/forma/sample/root/library/SampleApp.kt
@@ -21,6 +21,10 @@ import tools.forma.sample.common.util.clock.Clock
 import tools.forma.sample.core.di.library.BaseComponent
 import tools.forma.sample.core.di.library.BaseComponentProvider
 import tools.forma.sample.core.di.library.DaggerBaseComponent
+import tools.forma.sample.core.navigation.android.util.HomeShellNavigation
+import tools.forma.sample.core.navigation.android.util.HomeShellNavigationProvider
+import tools.forma.sample.core.navigation.api.Navigator
+import tools.forma.sample.core.navigation.api.NavigatorProvider
 import tools.forma.sample.core.network.library.Config
 import tools.forma.sample.core.theme.android.util.ThemeUtils
 import tools.forma.sample.core.theme.android.util.di.DaggerThemeComponent
@@ -35,15 +39,17 @@ import tools.forma.sample.feature.characters.favorite.api.di.CharacterFavoriteFe
 import tools.forma.sample.feature.characters.favorite.impl.di.CharacterFavoriteComponent
 import tools.forma.sample.feature.characters.favorite.impl.di.DaggerCharacterFavoriteComponent
 import tools.forma.sample.root.library.di.DaggerRootComponent
-import timber.log.Timber
+import tools.forma.sample.root.library.navigation.JetpackHomeShellNavigation
+import tools.forma.sample.root.library.navigation.JetpackNavigator
 import javax.inject.Inject
-import kotlin.random.Random
 
 class SampleApp : SplitCompatApplication(),
     BaseComponentProvider,
     ThemeComponentProvider,
     CharactersCoreFeatureProvider,
-    CharacterFavoriteFeatureProvider {
+    CharacterFavoriteFeatureProvider,
+    NavigatorProvider,
+    HomeShellNavigationProvider {
 
     private lateinit var baseComponent: BaseComponent
     override fun getBaseComponent(): BaseComponent = baseComponent
@@ -56,6 +62,14 @@ class SampleApp : SplitCompatApplication(),
 
     private lateinit var characterFavoriteComponent: CharacterFavoriteComponent
     override fun getCharacterFavoriteFeature(): CharacterFavoriteFeature = characterFavoriteComponent
+
+    private val jetpackNavigator = JetpackNavigator()
+    private val homeShellNavigation: HomeShellNavigation =
+        JetpackHomeShellNavigation(jetpackNavigator)
+
+    override fun getNavigator(): Navigator = jetpackNavigator
+
+    override fun getHomeShellNavigation(): HomeShellNavigation = homeShellNavigation
 
     @Inject
     lateinit var config: Config

--- a/application/root-app/src/main/java/tools/forma/sample/root/library/navigation/JetpackHomeShellNavigation.kt
+++ b/application/root-app/src/main/java/tools/forma/sample/root/library/navigation/JetpackHomeShellNavigation.kt
@@ -1,0 +1,59 @@
+package tools.forma.sample.root.library.navigation
+
+import android.content.Intent
+import androidx.appcompat.app.AppCompatActivity
+import androidx.fragment.app.FragmentManager
+import androidx.lifecycle.LifecycleOwner
+import androidx.navigation.ui.NavigationUI.setupActionBarWithNavController
+import com.google.android.material.bottomnavigation.BottomNavigationView
+import tools.forma.sample.core.navigation.android.util.HomeShellNavigation
+import tools.forma.sample.core.navigation.android.util.setupWithNavController
+import tools.forma.sample.core.navigation.library.R as NavR
+
+/**
+ * Jetpack multi-backstack bottom-nav + action-bar wiring for the home shell.
+ * Owns graph R.ids and NavController listeners; reports only a boolean chrome flag.
+ */
+class JetpackHomeShellNavigation(
+    private val jetpackNavigator: JetpackNavigator,
+) : HomeShellNavigation {
+
+    private val navGraphIds = listOf(
+        NavR.navigation.navigation_characters_list_graph,
+        NavR.navigation.navigation_character_favorite_graph,
+    )
+
+    private val tabRootDestinationIds = setOf(
+        NavR.id.characters_list_fragment,
+        NavR.id.character_favorite_fragment,
+    )
+
+    override fun bind(
+        activity: AppCompatActivity,
+        bottomNavigationView: BottomNavigationView,
+        fragmentManager: FragmentManager,
+        containerId: Int,
+        intent: Intent,
+        lifecycleOwner: LifecycleOwner,
+        onNavigationScreen: (Boolean) -> Unit,
+    ) {
+        val selectedNavController = bottomNavigationView.setupWithNavController(
+            navGraphIds = navGraphIds,
+            fragmentManager = fragmentManager,
+            containerId = containerId,
+            intent = intent,
+        )
+
+        selectedNavController.observe(lifecycleOwner) { navController ->
+            jetpackNavigator.attach(navController)
+            setupActionBarWithNavController(activity, navController)
+            navController.addOnDestinationChangedListener { _, destination, _ ->
+                onNavigationScreen(tabRootDestinationIds.contains(destination.id))
+            }
+            // Emit current destination chrome immediately.
+            navController.currentDestination?.id?.let { id ->
+                onNavigationScreen(tabRootDestinationIds.contains(id))
+            }
+        }
+    }
+}

--- a/application/root-app/src/main/java/tools/forma/sample/root/library/navigation/JetpackNavigator.kt
+++ b/application/root-app/src/main/java/tools/forma/sample/root/library/navigation/JetpackNavigator.kt
@@ -1,0 +1,40 @@
+package tools.forma.sample.root.library.navigation
+
+import androidx.navigation.NavController
+import tools.forma.sample.core.navigation.api.AppDestination
+import tools.forma.sample.core.navigation.api.Navigator
+import tools.forma.sample.feature.characters.list.impl.ui.CharactersListFragmentDirections
+
+/**
+ * Sole composition-root adapter that may import [NavController] + Safe Args *Directions.
+ * Feature `impl` never sees these types — Directions are generated into the fragment
+ * package name from XML, but compiled only via `core/navigation/res`.
+ *
+ * Multi-backstack: [attach] is called whenever the selected bottom-nav tab's
+ * NavController changes so [navigate]/[back] target the active graph.
+ */
+class JetpackNavigator : Navigator {
+
+    @Volatile
+    private var navController: NavController? = null
+
+    fun attach(controller: NavController) {
+        navController = controller
+    }
+
+    override fun navigate(to: AppDestination) {
+        val controller = navController ?: return
+        when (to) {
+            is AppDestination.CharacterDetail -> {
+                controller.navigate(
+                    CharactersListFragmentDirections
+                        .actionCharactersListFragmentToCharacterDetailFragment(to.characterId),
+                )
+            }
+        }
+    }
+
+    override fun back() {
+        navController?.navigateUp()
+    }
+}

--- a/docs/NAVIGATION-ABSTRACTION.md
+++ b/docs/NAVIGATION-ABSTRACTION.md
@@ -1,13 +1,14 @@
 # Navigation abstraction (F-102 / GH #46)
 
-**Status:** design shipped (this doc). Implementation is **not** a Forma engine
-feature — it is **sample architecture + progressive teaching**, with optional
-reuse of existing Path B `navigationRes` only where type=rule already fits.
+**Status:** design + implement slices shipped (F-102 / **F-111** / **F-112**).
+Implementation is **not** a Forma engine feature — it is **sample architecture +
+progressive teaching**, with optional reuse of existing Path B `navigationRes`
+only where type=rule already fits.
 
 | Slice | Ticket | Scope |
 |-------|--------|--------|
 | Design (this doc) | **F-102** | Problem, layers A/B, v1 approach, rejects, ticket map |
-| Sample ports + root adapter | **F-111** | Gold-standard `application/` refactor |
+| Sample ports + root adapter | **F-111** | Gold-standard `application/` refactor (**done**) |
 | Progressive example | **F-112** | `examples/android/12-navigation-ports` (shipped) |
 | Optional type tweaks | only if evidence | No new forever router DSL in plugins |
 
@@ -248,7 +249,7 @@ Documented pattern only:
 | ID | Status intent | Deliverable |
 |----|---------------|-------------|
 | **F-102** | **done** (design) | This document + cross-links + board split |
-| **F-111** | todo | Sample: presentation ports + adapter at composition root; strip Nav/Safe Args from feature `impl`/VM where practical; keep `navigationRes`; `application/` still green |
+| **F-111** | **done** | Sample: presentation ports + adapter at composition root; strip Nav/Safe Args from feature `impl`/VM where practical; keep `navigationRes`; `application/` still green |
 | **F-112** | done | Progressive example `examples/android/12-navigation-ports` + ladder/skill links |
 | F-102c (optional) | only if needed | Tiny type/docs tweak to `navigationRes` / TARGET-PLUGINS — **no** router engine |
 
@@ -263,20 +264,20 @@ order is fine as long as both follow this design.
 
 **F-111**
 
-- [ ] Navigator / destinations (or equivalent) with **no** androidx.navigation in
+- [x] Navigator / destinations (or equivalent) with **no** androidx.navigation in
       feature contracts used by `impl`/VM
-- [ ] Adapter at root (or root-owned module) owns `NavController` + Safe Args
-- [ ] Feature modules no longer depend on `core/navigation/res` unless justified
+- [x] Adapter at root (or root-owned module) owns `NavController` + Safe Args
+- [x] Feature modules no longer depend on `core/navigation/res` unless justified
       in PROGRESS
-- [ ] Comments/TODOs for GH #46 in touched files resolved or narrowed
-- [ ] `application/` `./gradlew :binary:assembleDebug` (or full `build`) green on
+- [x] Comments/TODOs for GH #46 in touched files resolved or narrowed
+- [x] `application/` `./gradlew :binary:assembleDebug` (or full `build`) green on
       real host — never invent green
 
 **F-112**
 
-- [ ] Example builds; README explains ports vs adapter vs `navigationRes`
-- [ ] `PROGRESSIVE-EXAMPLES.md` matrix row + examples README link
-- [ ] No `.withPlugin`; no `androidLibrary`
+- [x] Example builds; README explains ports vs adapter vs `navigationRes`
+- [x] `PROGRESSIVE-EXAMPLES.md` matrix row + examples README link
+- [x] No `.withPlugin`; no `androidLibrary`
 
 ---
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest entries first.
 
+## 2026-07-26 — F-111: Sample navigation ports + root adapter
+
+- **Ticket:** F-111 → `done` (GH #46 sample implement; design F-102 + teach F-112 already done)
+- **Branch:** `forma/F-111-sample-navigation-ports` (from `origin/v2`)
+- **Skills/modes:** Grok Build `--mode full` (design/plan + implement); Hermes finish path after CLI timeout (verify + docs + PR)
+- **Code (application/ only — no Forma engine DSL):**
+  - `core/navigation/api` (`api`) — `Navigator`, `NavigatorProvider`, sealed `AppDestination.CharacterDetail`, `CharacterDetailArgs.CHARACTER_ID`, `HomeChromeMode`
+  - `core/navigation/android-util` — moved multi-backstack `NavigationExtensions` from common; `HomeShellNavigation` / `HomeShellNavigationProvider` (boolean chrome flag — **no** `api` import so matrix `androidUtil` ↛ `api` holds)
+  - `root-app` — `JetpackNavigator` (rebindable `NavController` + Safe Args `CharactersListFragmentDirections`); `JetpackHomeShellNavigation` owns graph `R.navigation` / tab-root `R.id` + action bar; `SampleApp` implements both providers
+  - Features Nav-free: list/detail fragments use ports; detail reads plain Bundle key; `HomeViewModel` takes `HomeChromeMode` only; `HomeFragment` binds shell provider only
+  - Stripped `androidx.navigation` + `target(":core:navigation:res")` from list/detail/favorite/home feature modules + cargo-cult favorite viewbinding; common extensions no longer depends on navigation
+  - Layer B unchanged: `core/navigation/res` still `navigationRes`
+- **Verify (real host, `source scripts/env-mac.sh`):**
+  - `application/` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (1m7s, 623 tasks)
+  - `rg` under `application/feature` for `findNavController|FragmentDirections|navArgs(|androidx.navigation` → **no matches**
+  - `rg` `core:navigation:res` under `application/feature/**/build.gradle.kts` → **no matches**
+- **Docs:** NAVIGATION-ABSTRACTION DoD F-111 checked; SAMPLE-APP wiring sketch; TICKETS F-111 done; P11 header next = F-103
+- **Not in this slice:** F-103/F-104; Forma router engine; moving HomeFragment into root-app; optional `core/mvvm` unused nav dep cleanup
+- **Next step:** **F-103** hybrid targets example (flat dir / api+impl co-location)
+
 ## 2026-07-26 — F-112: Progressive example navigation ports
 
 - **Ticket:** F-112 → `done` (teach F-102 Layer A/B; sample migration remains **F-111**)

--- a/docs/SAMPLE-APP.md
+++ b/docs/SAMPLE-APP.md
@@ -94,9 +94,12 @@ binary (androidBinary)
 root-app hosts SampleApp DI:
   BaseComponent + ThemeComponent + CharactersCore + CharacterFavorite
 
-home/impl hosts bottom navigation:
-  navigation_characters_list_graph + navigation_character_favorite_graph
-  (from core/navigation/res)
+Navigation (F-111):
+  core/navigation/api          — Navigator + AppDestination + HomeChromeMode (no androidx.navigation)
+  core/navigation/android-util — HomeShellNavigation port + multi-backstack helpers
+  core/navigation/res          — Path B navigationRes (graphs + Safe Args)
+  root-app                     — JetpackNavigator + JetpackHomeShellNavigation (sole Nav/Safe Args consumer)
+  home/impl                    — thin shell; binds HomeShellNavigationProvider only
 ```
 
 ## Build
@@ -124,11 +127,13 @@ Not in scope for F-014: full navigation redesign (GH #46), publish path (F-016).
 Configuration-time performance: [CONFIGURATION-PERFORMANCE.md](CONFIGURATION-PERFORMANCE.md) (F-017).
 
 **Navigation abstraction (F-102 / GH #46):** design is in
-[NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md) — presentation-layer ports
-so feature `impl`/ViewModels do not take Jetpack Navigation / Safe Args codegen;
-graphs stay on `navigationRes`. Sample refactor = **F-111**; progressive example
+[NAVIGATION-ABSTRACTION.md](NAVIGATION-ABSTRACTION.md). **F-111 landed** on this
+sample: Layer A ports in `core/navigation/api`, Jetpack adapter in `root-app`,
+home multi-backstack binder port in `core/navigation/android-util`, graphs stay
+on `navigationRes`. Feature `impl`/VM have **no** `findNavController` / Safe Args /
+graph R.ids. Progressive teach:
 [`examples/android/12-navigation-ports`](../examples/android/12-navigation-ports)
-(**F-112**, shipped). This gold-standard tree still shows today’s bleed until F-111 lands.
+(**F-112**).
 
 ## Type-owned plugins (navigation)
 


### PR DESCRIPTION
## Summary
- Implements **F-111** (GH #46 sample): presentation-layer navigation ports so feature impl/VM stay free of Jetpack Navigation / Safe Args.
- **Layer A:** `core/navigation/api` — Navigator, AppDestination, HomeChromeMode, Bundle arg keys.
- **Adapter:** root-app JetpackNavigator + JetpackHomeShellNavigation; multi-backstack helpers moved to `core/navigation/android-util` (HomeShellNavigation port without depending on api — matrix).
- **Layer B unchanged:** `core/navigation/res` still Path B navigationRes.
- Stripped feature → core/navigation/res / androidx.navigation; cargo-cult favorite deps cleaned; GH #46 TODOs resolved.

## Verify
- `source scripts/env-mac.sh && cd application && ./gradlew :binary:assembleDebug` → BUILD SUCCESSFUL
- No findNavController / FragmentDirections / navArgs / androidx.navigation under application/feature Kotlin sources

## Test plan
- [x] assembleDebug green on worker host
- [ ] CI Plugins + Application jobs on PR

Next board: **F-103** hybrid targets example.
