### PR TITLE
F-115: NiA dogfood phase C (data/domain/designsystem + interests)

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -172,11 +172,11 @@ External multimodule OSS validation of meta-build axioms (structure over configu
 type-owned plugins, attrs-only call sites, closed matrix). **Not** another in-repo sample.
 
 Open coding: **F-115** (`in_progress`). **F-094** Portal remains `blocked` (human).
-4h workers: pick F-115 phase B+ unless blocked; do not `[SILENT]` while F-115 is open.
+4h workers: pick F-115 phase C remainder (Hilt Path A / more features) unless blocked; do not `[SILENT]` while F-115 is open.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-115 | in_progress | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B done:** mavenLocal `0.1.3-NIA` + `/Users/claw/work/nowinandroid-forma/forma-spike` `:binary:assembleDebug` **green**. Findings F1/F8/F9 applied in spike. **Phase C:** expand real topic deps (data/Hilt/designsystem) + more features. No `androidLibrary`. |
+| F-115 | in_progress | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C partial done:** spike green with data/domain `androidUtil`, designsystem `uiLibrary`, topic ViewModel, interests feature (no impl→impl). Finding F11 (`compose=false` on non-UI androidUtil). **Next phase C:** Hilt Path A, Room/Firebase, more features. No `androidLibrary`. |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/DOGFOOD-NIA.md
+++ b/docs/DOGFOOD-NIA.md
@@ -1,6 +1,6 @@
 # Dogfood: Now in Android → Forma (F-115)
 
-**Status:** `in_progress` — phase B vertical spike **green**  
+**Status:** `in_progress` — phase C (data/domain/designsystem + interests) **green**  
 **Upstream:** [android/nowinandroid](https://github.com/android/nowinandroid) (Apache-2.0)  
 **Pinned checkout (local):** `/Users/claw/work/nowinandroid` @ `7d45eae` (main tip when cloned 2026-07-29)  
 **Dogfood fork:** `/Users/claw/work/nowinandroid-forma`  
@@ -183,16 +183,22 @@ Workspace: **`/Users/claw/work/nowinandroid-forma/forma-spike`** (external consu
 
 **Real NiA DNA in spike:** `Topic` / `FollowableTopic` model sources; topic package namespace; topic strings moved to `androidRes`; Navigator port instead of Nav3 on api.
 
-**Not yet (phase C):** full upstream `TopicScreen`/`TopicViewModel` (Hilt, `core.data`, designsystem, `core.ui`); multi-feature app; flavors; Room/Firebase Path A on this tree.
+**Not yet (phase C remainder):** Hilt Path A; Room/Firebase; full upstream designsystem/core.ui; remaining features (foryou/bookmarks/search/settings); flavors.
 
-### Phase C — Expand features + cores
+### Phase C — Expand features + cores (partial ✅ 2026-07-29)
 
-- Grow spike toward real topic impl deps (data/domain as `androidUtil`)  
-- foryou / interests / bookmarks / search / settings  
-- Hilt Path A on impl (+ binary)  
-- Room derived type on database  
-- Firebase on binary  
-- Optional: hybrid stub pairs for IDE  
+Workspace: same **`forma-spike`** external tree.
+
+| Step | Result |
+|------|--------|
+| Cores | `core-data-android-util` (`TopicsRepository` + in-memory), `core-domain-android-util` (`GetFollowableTopicsUseCase`), `core-designsystem-ui-library` (slim `NiaTheme` / loading / background) |
+| Topic | `TopicViewModel` + designsystem-backed `TopicRoute` / `TopicScreen` (manual DI) |
+| Interests | `feature-interests-{api,res,impl}` — domain use case; navigates via **topic api** only |
+| Root | Manual DI graph + multi-destination Navigator adapter |
+| Verify | `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (198 tasks); APK ~9.2 MB |
+| Finding F11 | Project-global `compose=true` forces Compose compiler on `androidUtil` unless `compose = false` — set on data/domain |
+
+**Still open in phase C:** Hilt Path A (type-owned like Metro F-095), Room derived type, Firebase binary, foryou/bookmarks/search/settings, full designsystem port.
 
 ### Phase D — Case study write-up
 
@@ -206,11 +212,12 @@ Workspace: **`/Users/claw/work/nowinandroid-forma/forma-spike`** (external consu
 |----|------|--------------|------------|
 | F1 | 2026-07-29 | feature api → navigation android lib | **Spike:** `core-navigation-api` pure `Navigator` port; `TopicNavKey` drops `NavKey`; adapter in `root-app` |
 | F2 | 2026-07-29 | search api → domain | Still open (search not in spike) |
-| F3 | 2026-07-29 | ui → model vs uiLibrary matrix | Deferred (no `uiLibrary` in spike); model consumed as JVM `library` from `impl` (**allowed**) |
-| F5 | 2026-07-29 | test impl→impl | Deferred |
+| F3 | 2026-07-29 | ui → model vs uiLibrary matrix | **Phase C:** `uiLibrary` designsystem has **no** model edge; model flows `impl` → JVM `library` (**allowed**). F3 gap stays if designsystem must import model types later |
+| F5 | 2026-07-29 | test / runtime impl→impl | **Phase C runtime:** interests.impl → topic.**api** only. Test classpath still deferred |
 | F8 | 2026-07-29 | upstream topic **api** ships `res/strings` | **Spike:** `feature/topic/res` `androidRes`; `api` has no `res/` (matrix content rule) |
 | F9 | 2026-07-29 | `tools.forma.includer` **not** published to mavenLocal | External consumer used **flat** `include(":feature-topic-api")` + `projectDir`; Forma `target(":feature:topic:api")` → `:feature-topic-api`. Product gap: publish includer or document flat-name recipe in PLUGIN-PUBLISH |
 | F10 | 2026-07-29 | First target() resolve failed with nested `:feature:topic:api` includes | Confirmed path mapping; flat names required without includer |
+| F11 | 2026-07-29 | project-global `compose=true` + `androidUtil` | Compose compiler runs on data/domain without Compose runtime → ICE. **Fix:** `androidUtil(..., compose = false)` on non-UI cores |
 
 ## Local reference commands
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,22 @@
 
 Newest entries first.
 
+## 2026-07-29 — F-115: NiA dogfood phase C (data/domain/designsystem + interests)
+
+- **Ticket:** F-115 still `in_progress` (Hilt Path A / Room / remaining features next)
+- **Skills/modes:** Hermes direct dogfood scaffold (external spike; no Forma engine DSL change)
+- **External tree:** `/Users/claw/work/nowinandroid-forma/forma-spike`
+  - Added `core-data-android-util`, `core-domain-android-util`, `core-designsystem-ui-library`
+  - Topic: `TopicViewModel` + designsystem-backed screen; deps on data + uiLibrary
+  - Interests: `feature-interests-{api,res,impl}` using domain use case; navigates via topic **api** only
+  - Root: manual DI + multi-destination Navigator adapter
+  - **F11:** `compose = false` on non-UI `androidUtil` (project-global compose otherwise ICE)
+- **Verify (real host):** `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (198 tasks); APK `binary-debug.apk` ~9.2MB
+- **Docs:** `docs/DOGFOOD-NIA.md` phase C + findings F3/F5/F11; TICKETS F-115 notes
+- **Commits/PRs:** this branch → PR base `v2`
+- **Blockers:** none product; F-094 Portal still human-blocked
+- **Next:** Hilt Path A (type-owned like Metro), or more features / Room derived type
+
 ## 2026-07-29 — F-115: NiA dogfood phase B vertical spike green
 
 - **Ticket:** F-115 still `in_progress` (phase C next)


### PR DESCRIPTION
## Summary
- F-115 phase C **partial**: external spike `/Users/claw/work/nowinandroid-forma/forma-spike` expanded with:
  - `core-data-android-util` + `core-domain-android-util` (in-memory repos + `GetFollowableTopicsUseCase`)
  - `core-designsystem-ui-library` (slim NiaTheme / loading / background)
  - topic ViewModel + designsystem-backed UI
  - interests feature (domain use case; navigates via **topic api** only — no `impl`→`impl`)
  - root manual DI + multi-destination Navigator adapter
- **Finding F11:** project-global `compose=true` forces Compose compiler on non-UI `androidUtil` → set `compose = false` on data/domain
- Docs: `DOGFOOD-NIA.md`, `TICKETS.md`, `PROGRESS.md`
- No Forma engine changes; no `androidLibrary`

## Verify
```bash
source scripts/env-mac.sh
bash scripts/publish-local.sh 0.1.3-NIA
cd /Users/claw/work/nowinandroid-forma/forma-spike
./gradlew :binary:assembleDebug   # BUILD SUCCESSFUL (198 tasks), APK ~9.2MB
```

## Next
Hilt Path A (type-owned like Metro), Room/Firebase, more NiA features.