### PR TITLE
docs: audit cron continuation gate + F-115 priority:now

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -171,12 +171,12 @@ composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 External multimodule OSS validation of meta-build axioms (structure over configuration,
 type-owned plugins, attrs-only call sites, closed matrix). **Not** another in-repo sample.
 
-Open coding: **F-115** (`in_progress`). **F-094** Portal remains `blocked` (human).
-4h workers: pick F-115 phase C remainder (more features / DataStore / sync) unless blocked; do not `[SILENT]` while F-115 is open.
+Open coding: **F-115** (`in_progress`, **`priority: now`**, **cron may continue**). **F-094** Portal remains `blocked` (human).
+4h workers: pick F-115 phase C remainder (more features / DataStore / sync) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-115 | in_progress | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase done:** spike green with Hilt Path A + Room Path B + **Firebase Path A** (`hiltFirebaseBinary`, dummy GMS JSON, Analytics/Crashlytics API on binary). Engine: KSP companion (F12) + `androidUtilTarget` (F15). Findings F16/F17 (stack Path A; `transitiveDeps` for Firebase SDKs). **Next phase C:** more features / DataStore / sync. No `androidLibrary`. |
+| F-115 | in_progress | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore done:** spike green with Hilt Path A + Room Path B + Firebase Path A + **Preferences DataStore** UserData (`core-datastore-android-util`, `OfflineFirstUserDataRepository`, `FollowTopicUseCase`). Engine: KSP companion (F12) + `androidUtilTarget` (F15). Findings F16–F19. **Next phase C:** more features / WorkManager sync / Proto DataStore. No `androidLibrary`. |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,32 @@
 
 Newest entries first.
 
+## 2026-07-30 — F-115: NiA dogfood DataStore Preferences UserData
+
+- **Ticket:** F-115 still `in_progress` (more features / WorkManager sync / Proto DataStore next)
+- **Skills/modes:** Hermes direct dogfood (external spike + docs; no Forma engine DSL change)
+- **External tree:** `/Users/claw/work/nowinandroid-forma/forma-spike`
+  - `core-datastore-android-util` — Preferences DataStore + `NiaPreferencesDataSource` + Hilt `DataStoreModule`
+  - data: `OfflineFirstUserDataRepository` replaces in-memory UserData; deps → datastore
+  - domain: `FollowTopicUseCase` (F19 — interests stays domain-only)
+  - interests UI: Follow chip writes DataStore via use case
+  - Findings **F18** (DataStore = library stack, no Gradle plugin), **F19** (feature→data via domain use case)
+- **Verify (real host):**
+  - `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (291 tasks)
+  - `:core-datastore-android-util:compileDebugKotlin` green; Hilt aggregate green
+- **Docs:** `docs/DOGFOOD-NIA.md` phase C DataStore + F18/F19; TICKETS F-115 notes; spike README
+- **Commits/PRs:** this branch → PR base `v2`
+- **Blockers:** none product; F-094 Portal still human-blocked
+- **Next:** more NiA features (foryou/bookmarks/search/settings) and/or WorkManager sync
+
+## 2026-07-30 — F-115: NiA dogfood Firebase Path A + transitive Firebase SDKs
+
+- **Source:** Audit topic 4241 — implement 2026-07-29 recommendations (Hermes skills + local cron prompts; this repo slice is board/prompt only)
+- **Board:** F-115 tagged `priority: now` + `cron may continue` so 4h worker may keep dogfood under the new gate
+- **Docs:** `docs/cron-worker-prompt.txt` — continuation gate + rm -rf path echo; merge only gated ticket PRs
+- **Live cron:** `~/.hermes/cron/jobs.json` job `18717ea2093c` prompt patched (backup `jobs.json.bak-audit-impl-20260730`)
+- **No product code** in this slice
+
 ## 2026-07-30 — F-115: NiA dogfood Firebase Path A + transitive Firebase SDKs
 
 - **Ticket:** F-115 still `in_progress` (more features / DataStore / sync next)

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -20,7 +20,7 @@ Newest entries first.
 - **Blockers:** none product; F-094 Portal still human-blocked
 - **Next:** more NiA features (foryou/bookmarks/search/settings) and/or WorkManager sync
 
-## 2026-07-30 — F-115: NiA dogfood Firebase Path A + transitive Firebase SDKs
+## 2026-07-30 — Audit policy: cron continuation gate (docs)
 
 - **Source:** Audit topic 4241 — implement 2026-07-29 recommendations (Hermes skills + local cron prompts; this repo slice is board/prompt only)
 - **Board:** F-115 tagged `priority: now` + `cron may continue` so 4h worker may keep dogfood under the new gate

--- a/docs/cron-worker-prompt.txt
+++ b/docs/cron-worker-prompt.txt
@@ -6,18 +6,37 @@ Make formatools/forma a working Android product, then extract forma-core (depend
 ## Workdir
 Always operate in /Users/claw/work/forma. Follow AGENTS.md strictly.
 
+## Role split (mandatory)
+- **You (Hermes)** = orchestrator: pick ticket, branch hygiene, write Grok prompt, run Grok Build CLI with skills, verify git/build, update TICKETS/PROGRESS, commit/PR/merge, report.
+- **Grok Build CLI** = implementer using built-in skills/agents (design / goal / implement / check-work / review).
+- Do **not** implement ticket code yourself with Hermes patch/write loops. Bookkeeping-only edits (TICKETS.md / PROGRESS.md) are allowed if Grok left them incomplete.
+
 ## Each run (do all of this)
 1. Read AGENTS.md, docs/VISION.md, TICKETS.md, and the latest entries in docs/PROGRESS.md.
 2. git status / git branch / git log -5. Prefer continuing forma/* branches; otherwise branch from origin/v2 as forma/F-XXX-slug (v2 is the base of operations; do not start work from master).
-3. Select the highest-priority ticket with status todo or in_progress (never reorder priorities).
-4. Execute a meaningful slice for that ticket (code, build fixes, docs, toolchain). Prefer shippable PR-sized work over sprawling rewrites.
-5. Update TICKETS.md status and append a dated section to docs/PROGRESS.md (ticket id, what changed, commits/PRs, blockers, next step).
-6. Commit workspace/docs + code changes with message "F-XXX: concise summary". Open a GitHub PR against base **v2** when the slice is coherent (`gh pr create --base v2` on formatools/forma).
-7. **Auto-merge into v2:** After opening (or finding) an open PR with base `v2`, if checks are green (or none required) and it is mergeable, squash-merge it: `gh pr merge <N> --squash --delete-branch`. Prefer `gh pr merge <N> --auto --squash --delete-branch` when still waiting on CI. Do not merge PRs targeting `master` unless the user asked. Close stale master-base PRs whose commits are already on `origin/v2`.
-8. Final response = concise human report: ticket worked, progress, PR links, merge status, blockers. The scheduler delivers it — do NOT use send_message.
+3. Select the highest-priority ticket with status todo or in_progress that also passes the **cron continuation gate** below (never reorder priorities).
+4. Write a self-contained prompt file for Grok Build CLI covering ticket id, AC, branch, AGENTS constraints, verify commands, explicit /goal text.
+5. Run Grok Build via ~/.hermes/scripts/grok_build_exec.sh (cwd /Users/claw/work/forma, model grok-4.5).
+6. After CLI exits: inspect git status/diff. Update TICKETS.md + docs/PROGRESS.md.
+7. Commit with message "F-XXX: concise summary". Open PR base **v2** when coherent.
+8. **Auto-merge into v2** for the gated ticket’s PR only: `gh pr merge <N> --squash --delete-branch` or `--auto` while CI runs. Do not mass-merge unrelated PRs. Do not merge master-base unless asked.
+9. Final response = concise human report. Scheduler delivers — do NOT use send_message.
+
+## Cron continuation gate (audit 2026-07-29)
+Interactive Telegram “Go ahead” alone does **not** authorize unbounded multi-slice cron work.
+Only pick/code/merge a ticket when it is `todo`/`in_progress` **and** (`priority: now` on the board row **or** TICKETS/PROGRESS says `cron may continue` for that F-xxx).
+Otherwise respond exact **[SILENT]** (do not invent tickets; do not expand scope).
+
+## Destructive shell
+`rm -rf` only on paths created in-session / clearly named ticket throwaways. Always echo the absolute path before delete.
+
+## Idle / blocked-only board
+If every open ticket is **blocked** on human/admin and nothing is gated `todo`/`in_progress`:
+- Do **not** re-verify the world or invent F-xxx tickets.
+- Respond with exact **[SILENT]**.
 
 ## Constraints
-- No Java today may block Gradle: if so, prioritize F-001 (install Temurin 17+ / document SDK needs) before pretending builds pass.
+- No Java today may block Gradle: if so, prioritize F-001 before pretending builds pass.
 - Never invent green builds — ground claims in command output.
 - Do not create/modify other cron jobs.
 - Do not force-push master or v2 on upstream.


### PR DESCRIPTION
## Summary
- Implements Audit 2026-07-29 recommendation for forma 4h autonomy: continue only when board has `priority: now` or `cron may continue`.
- Tags **F-115** so NiA dogfood stays authorized under the new gate.
- Syncs `docs/cron-worker-prompt.txt` (rm -rf path echo; gated merge).

Live Hermes cron `18717ea2093c` prompt was patched separately (`jobs.json.bak-audit-impl-20260730`).

## Test plan
- [x] Diff review only (docs/board)
- [ ] Next 4h tick respects gate language