### PR TITLE
F-115: NiA dogfood For You feature + news feed

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -176,7 +176,7 @@ Open coding: **F-115** (`in_progress`, **`priority: now`**, **cron may continue*
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore done:** spike green with Hilt Path A + Room Path B + Firebase Path A + **Preferences DataStore** UserData (`core-datastore-android-util`, `OfflineFirstUserDataRepository`, `FollowTopicUseCase`). Engine: KSP companion (F12) + `androidUtilTarget` (F15). Findings F16–F19. **Next phase C:** more features / WorkManager sync / Proto DataStore. No `androidLibrary`. |
+| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore+ForYou done:** spike green with Hilt Path A + Room Path B + Firebase Path A + Preferences DataStore + **`feature-foryou`** (news feed Room v2, onboarding, bookmarks prefs). Findings F16–F20. **Next phase C:** bookmarks/search/settings / WorkManager sync / Proto DataStore. No `androidLibrary`. |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/DOGFOOD-NIA.md
+++ b/docs/DOGFOOD-NIA.md
@@ -1,6 +1,6 @@
 # Dogfood: Now in Android → Forma (F-115)
 
-**Status:** `in_progress` — phase C Hilt + Room + Firebase + **DataStore Preferences green** (more features / sync next)  
+**Status:** `in_progress` — phase C Hilt + Room + Firebase + DataStore + **For You feature green** (bookmarks/search/settings / sync next)  
 **Upstream:** [android/nowinandroid](https://github.com/android/nowinandroid) (Apache-2.0)  
 **Pinned checkout (local):** `/Users/claw/work/nowinandroid` @ `7d45eae` (main tip when cloned 2026-07-29)  
 **Dogfood fork:** `/Users/claw/work/nowinandroid-forma`  
@@ -251,7 +251,21 @@ Workspace: same **`forma-spike`** external tree.
 | Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (291 tasks) |
 | Deferred | Proto DataStore + `datastore-proto` (upstream NiA shape) — later if needed |
 
-**Still open in phase C:** remaining NiA features (foryou/bookmarks/search/settings), flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+**Still open in phase C (pre-For You):** remaining NiA features (foryou/bookmarks/search/settings), flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+
+### Phase C — For You feature + news feed ✅ (2026-07-30)
+
+| Step | Result |
+|------|--------|
+| Model | `NewsResource` + `UserNewsResource` on JVM `library` (ISO date string; no kotlinx-datetime) |
+| Room v2 | `NewsResourceEntity` / `NewsResourceDao`; schema `2.json`; destructive migrate on spike |
+| Data | `NewsRepository` + bookmarks/onboarding on DataStore-backed `UserData` |
+| Domain | `GetNewsFeedForFollowedTopics` / `BookmarkNewsResource` / onboarding use cases (F19) |
+| Feature | `feature-foryou-{api,res,impl}` — home start; feed + onboarding + bookmark; → interests/topic **api** only |
+| Root | `MainActivity` start = `ForYouNavKey`; multi-dest Navigator |
+| Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (335 tasks); APK ~12.8 MB |
+
+**Still open in phase C:** bookmarks/search/settings features, flavors, full designsystem, Proto DataStore parity, WorkManager sync.
 
 ### Phase D — Case study write-up
 
@@ -279,6 +293,7 @@ Workspace: same **`forma-spike`** external tree.
 | F17 | 2026-07-30 | Firebase SDKs via `.dep` / `deps()` non-transitive | Crashlytics/Analytics AARs resolve but **without** `firebase-common` → `FirebaseApp` unresolved on binary. **Fix:** type-owned companions use `transitiveDeps(...)` (BOM still `transitivePlatform`). Example 14 companions fixed the same way. |
 | F18 | 2026-07-30 | DataStore has no structure Gradle plugin | Preferences DataStore is a **library stack** on `hiltAndroidUtil` (companions at call site). No Path A/B plugin id. Proto DataStore would add JVM `library` + serializer — deferred; Preferences enough to validate UserData edge + follow toggle. |
 | F19 | 2026-07-30 | Feature VM → data types without matrix edge | interests.impl depended on domain only; injecting `UserDataRepository` failed KSP resolve. **Fix:** `FollowTopicUseCase` on domain — feature stays domain-facing (cleaner than adding data edge). |
+| F20 | 2026-07-30 | Multi-feature composition at root | foryou + interests + topic: each `impl` only → other feature **api**; root-app/binary compose all three. Start dest = For You (NiA home). Confirms F5 at 3-feature scale. |
 
 ## Local reference commands
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest entries first.
 
+## 2026-07-30 — F-115: NiA dogfood For You feature + news feed
+
+- **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (bookmarks/search/settings / WorkManager next)
+- **Skills/modes:** Hermes direct dogfood (external spike + docs; no Forma engine DSL change)
+- **External tree:** `/Users/claw/work/nowinandroid-forma/forma-spike`
+  - Model: `NewsResource` / `UserNewsResource`
+  - Room v2: `NewsResourceEntity`/`NewsResourceDao` + schema `2.json` + destructive migrate
+  - DataStore: bookmarks + `shouldHideOnboarding` keys
+  - Data: `NewsRepository` + extended `UserData`
+  - Domain: feed/bookmark/onboarding use cases (F19)
+  - Feature: `feature-foryou-{api,res,impl}` — home start; → interests/topic **api** only (F20)
+  - Root: multi-dest Navigator; start = For You
+- **Verify (real host):**
+  - `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (335 tasks)
+  - APK `binary-debug.apk` ~12.8 MB
+- **Docs:** `docs/DOGFOOD-NIA.md` phase C For You + F20; TICKETS F-115 notes; spike README
+- **Commits/PRs:** this branch → PR base `v2`
+- **Blockers:** none product; F-094 Portal still human-blocked
+- **Next:** bookmarks/search/settings and/or WorkManager sync
+
 ## 2026-07-30 — F-115: NiA dogfood DataStore Preferences UserData
 
 - **Ticket:** F-115 still `in_progress` (more features / WorkManager sync / Proto DataStore next)


### PR DESCRIPTION
## Summary
- F-115 phase C: **For You** feature on external `forma-spike` (news feed Room v2, DataStore bookmarks/onboarding, domain use cases, multi-feature root)
- Docs: `DOGFOOD-NIA.md` + finding **F20**, TICKETS/PROGRESS notes
- Verify: `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (335 tasks); APK ~12.8 MB

## External spike (not in this repo)
`/Users/claw/work/nowinandroid-forma/forma-spike` — `feature-foryou-{api,res,impl}`, `NewsRepository`, feed filtered by followed topics; start dest = For You; no `androidLibrary`, no impl→impl.

## Test plan
- [x] Host assembleDebug green on spike
- [ ] CI docs-only PR green