### PR TITLE
F-115: NiA dogfood Bookmarks (Saved) feature

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -172,11 +172,11 @@ External multimodule OSS validation of meta-build axioms (structure over configu
 type-owned plugins, attrs-only call sites, closed matrix). **Not** another in-repo sample.
 
 Open coding: **F-115** (`in_progress`, **`priority: now`**, **cron may continue**). **F-094** Portal remains `blocked` (human).
-4h workers: pick F-115 phase C remainder (more features / WorkManager sync / Proto DataStore) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
+4h workers: pick F-115 phase C remainder (search/settings / WorkManager sync / Proto DataStore) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore+ForYou done:** spike green with Hilt Path A + Room Path B + Firebase Path A + Preferences DataStore + **`feature-foryou`** (news feed Room v2, onboarding, bookmarks prefs). Findings F16–F20. **Next phase C:** bookmarks/search/settings / WorkManager sync / Proto DataStore. No `androidLibrary`. |
+| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore+ForYou+Bookmarks done:** spike green with Hilt Path A + Room Path B + Firebase Path A + Preferences DataStore + **`feature-foryou`** + **`feature-bookmarks`** (Saved list + undo; domain use cases). Findings F16–F20 (4-feature root). **Next phase C:** search/settings / WorkManager sync / Proto DataStore. No `androidLibrary`. |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/DOGFOOD-NIA.md
+++ b/docs/DOGFOOD-NIA.md
@@ -1,6 +1,6 @@
 # Dogfood: Now in Android → Forma (F-115)
 
-**Status:** `in_progress` — phase C Hilt + Room + Firebase + DataStore + **For You feature green** (bookmarks/search/settings / sync next)  
+**Status:** `in_progress` — phase C Hilt + Room + Firebase + DataStore + For You + **Bookmarks feature green** (search/settings / sync next)  
 **Upstream:** [android/nowinandroid](https://github.com/android/nowinandroid) (Apache-2.0)  
 **Pinned checkout (local):** `/Users/claw/work/nowinandroid` @ `7d45eae` (main tip when cloned 2026-07-29)  
 **Dogfood fork:** `/Users/claw/work/nowinandroid-forma`  
@@ -265,7 +265,20 @@ Workspace: same **`forma-spike`** external tree.
 | Root | `MainActivity` start = `ForYouNavKey`; multi-dest Navigator |
 | Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (335 tasks); APK ~12.8 MB |
 
-**Still open in phase C:** bookmarks/search/settings features, flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+**Still open in phase C (pre-Bookmarks):** search/settings features, flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+
+
+### Phase C — Bookmarks feature (Saved) ✅ (2026-07-30)
+
+| Step | Result |
+|------|--------|
+| Domain | `GetBookmarkedNewsResourcesUseCase` — news ∩ bookmarked ids (F19) |
+| Feature | `feature-bookmarks-{api,res,impl}` — Saved list + remove + snackbar undo |
+| Edges | bookmarks.impl → topic.**api** + foryou.**api** only (F5); foryou → bookmarks.**api** |
+| Root | `BookmarksNavKey` in Navigator; For You header opens Saved |
+| Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (377 tasks); APK ~13 MB |
+
+**Still open in phase C:** search/settings features, flavors, full designsystem, Proto DataStore parity, WorkManager sync.
 
 ### Phase D — Case study write-up
 
@@ -293,7 +306,7 @@ Workspace: same **`forma-spike`** external tree.
 | F17 | 2026-07-30 | Firebase SDKs via `.dep` / `deps()` non-transitive | Crashlytics/Analytics AARs resolve but **without** `firebase-common` → `FirebaseApp` unresolved on binary. **Fix:** type-owned companions use `transitiveDeps(...)` (BOM still `transitivePlatform`). Example 14 companions fixed the same way. |
 | F18 | 2026-07-30 | DataStore has no structure Gradle plugin | Preferences DataStore is a **library stack** on `hiltAndroidUtil` (companions at call site). No Path A/B plugin id. Proto DataStore would add JVM `library` + serializer — deferred; Preferences enough to validate UserData edge + follow toggle. |
 | F19 | 2026-07-30 | Feature VM → data types without matrix edge | interests.impl depended on domain only; injecting `UserDataRepository` failed KSP resolve. **Fix:** `FollowTopicUseCase` on domain — feature stays domain-facing (cleaner than adding data edge). |
-| F20 | 2026-07-30 | Multi-feature composition at root | foryou + interests + topic: each `impl` only → other feature **api**; root-app/binary compose all three. Start dest = For You (NiA home). Confirms F5 at 3-feature scale. |
+| F20 | 2026-07-30 | Multi-feature composition at root | foryou + bookmarks + interests + topic: each `impl` only → other feature **api**; root-app/binary compose all four. Start dest = For You (NiA home). Confirms F5 at 4-feature scale. |
 
 ## Local reference commands
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,23 @@
 
 Newest entries first.
 
+## 2026-07-30 — F-115: NiA dogfood Bookmarks (Saved) feature
+
+- **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (search/settings / WorkManager next)
+- **Skills/modes:** Hermes direct dogfood (external spike + docs; no Forma engine DSL change)
+- **External tree:** `/Users/claw/work/nowinandroid-forma/forma-spike`
+  - Domain: `GetBookmarkedNewsResourcesUseCase` (news ∩ bookmarked ids; F19)
+  - Feature: `feature-bookmarks-{api,res,impl}` — Saved list, remove, snackbar undo
+  - Edges: bookmarks → topic/foryou **api** only; foryou → bookmarks **api** (F5/F20)
+  - Root: `BookmarksNavKey` + For You “Saved” entry; 4-feature composition
+- **Verify (real host):**
+  - `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (377 tasks)
+  - APK `binary-debug.apk` ~13 MB
+- **Docs:** `docs/DOGFOOD-NIA.md` phase C Bookmarks + F20 scale-up; TICKETS F-115 notes; spike README
+- **Commits/PRs:** this branch → PR base `v2`
+- **Blockers:** none product; F-094 Portal still human-blocked
+- **Next:** search/settings and/or WorkManager sync / Proto DataStore
+
 ## 2026-07-30 — F-115: NiA dogfood For You feature + news feed
 
 - **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (bookmarks/search/settings / WorkManager next)


### PR DESCRIPTION
## Summary
- F-115 phase C: **Bookmarks (Saved)** feature on external NiA Forma spike
- Domain `GetBookmarkedNewsResourcesUseCase` (F19); feature api/res/impl attrs-only
- Root composes 4 features (foryou + bookmarks + interests + topic); no impl→impl
- Verified: `forma-spike` `./gradlew :binary:assembleDebug` **BUILD SUCCESSFUL** (377 tasks)

## Test plan
- [x] Host assembleDebug green on `/Users/claw/work/nowinandroid-forma/forma-spike`
- [x] Docs: DOGFOOD-NIA + TICKETS + PROGRESS