### PR TITLE
F-115: NiA dogfood Settings feature + F22

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -172,11 +172,11 @@ External multimodule OSS validation of meta-build axioms (structure over configu
 type-owned plugins, attrs-only call sites, closed matrix). **Not** another in-repo sample.
 
 Open coding: **F-115** (`in_progress`, **`priority: now`**, **cron may continue**). **F-094** Portal remains `blocked` (human).
-4h workers: pick F-115 phase C remainder (settings / WorkManager sync / Proto DataStore) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
+4h workers: pick F-115 phase C remainder (WorkManager sync / Proto DataStore / flavors) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore+ForYou+Bookmarks+Search done:** spike green with Hilt Path A + Room Path B + Firebase Path A + Preferences DataStore + **`feature-foryou`** + **`feature-bookmarks`** + **`feature-search`** (query + recent + results; domain-only; **F2 closed** — api has no domain edge). Findings F16–F21 (5-feature root). **Next phase C:** settings / WorkManager sync / Proto DataStore. No `androidLibrary`. |
+| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore+ForYou+Bookmarks+Search+Settings done:** spike green with Hilt Path A + Room Path B + Firebase Path A + Preferences DataStore + **`feature-foryou`** + **`feature-bookmarks`** + **`feature-search`** + **`feature-settings`** (theme brand/dark/dynamic via domain; **F22** settings-api added for F1 ports). Findings F16–F22 (6-feature root). **Next phase C:** WorkManager sync / Proto DataStore / flavors. No `androidLibrary`. |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/DOGFOOD-NIA.md
+++ b/docs/DOGFOOD-NIA.md
@@ -1,6 +1,6 @@
 # Dogfood: Now in Android → Forma (F-115)
 
-**Status:** `in_progress` — phase C Hilt + Room + Firebase + DataStore + For You + Bookmarks + **Search feature green** (settings / sync next)  
+**Status:** `in_progress` — phase C Hilt + Room + Firebase + DataStore + For You + Bookmarks + Search + **Settings feature green** (WorkManager / Proto DataStore next)  
 **Upstream:** [android/nowinandroid](https://github.com/android/nowinandroid) (Apache-2.0)  
 **Pinned checkout (local):** `/Users/claw/work/nowinandroid` @ `7d45eae` (main tip when cloned 2026-07-29)  
 **Dogfood fork:** `/Users/claw/work/nowinandroid-forma`  
@@ -293,7 +293,22 @@ Workspace: same **`forma-spike`** external tree.
 | Root | `SearchNavKey` in Navigator; For You “Search” entry; **5-feature** composition (F21) |
 | Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (420 tasks); APK ~13 MB |
 
-**Still open in phase C:** settings feature, flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+**Still open in phase C (pre-Settings):** settings feature, flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+
+### Phase C — Settings feature ✅ (2026-07-31)
+
+| Step | Result |
+|------|--------|
+| DataStore | theme brand / dark config / dynamic color keys on Preferences (F18) |
+| Data | `UserData` + `UserDataRepository` theme setters |
+| Domain | `GetUserEditableSettings` + update brand/dark/dynamic use cases (F19) |
+| Feature | `feature-settings-{api,res,impl}` — theme radios + links panel (no OSS licenses activity) |
+| **F22** | upstream settings is **impl-only**; spike adds **settings-api** for NavKey ports (F1) |
+| Edges | settings.impl → domain/model/designsystem/nav only (no other feature); foryou → settings **api** |
+| Root | `SettingsNavKey`; For You “Settings” entry; **6-feature** composition |
+| Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (463 tasks); APK ~13 MB |
+
+**Still open in phase C:** flavors, full designsystem, Proto DataStore parity, WorkManager sync.
 
 ### Phase D — Case study write-up
 
@@ -323,6 +338,7 @@ Workspace: same **`forma-spike`** external tree.
 | F19 | 2026-07-30 | Feature VM → data types without matrix edge | interests.impl depended on domain only; injecting `UserDataRepository` failed KSP resolve. **Fix:** `FollowTopicUseCase` on domain — feature stays domain-facing (cleaner than adding data edge). |
 | F20 | 2026-07-30 | Multi-feature composition at root | foryou + bookmarks + interests + topic: each `impl` only → other feature **api**; root-app/binary compose all four. Start dest = For You (NiA home). Confirms F5 at 4-feature scale. |
 | F21 | 2026-07-31 | Search + 5-feature root | search.impl → topic/interests/foryou **api** only; root composes five features. Recent queries on DataStore (F18). Contains-search over Room (no FTS) still proves matrix + F2. |
+| F22 | 2026-07-31 | Settings upstream impl-only | NiA `:feature:settings:impl` has no api module. Spike adds `settings-api` (SettingsNavKey only) so root/other features navigate via **api** ports (F1) without depending on settings impl. Theme prefs on Preferences DataStore — still no Proto. |
 
 ## Local reference commands
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest entries first.
 
+## 2026-07-31 — F-115: NiA dogfood Settings feature
+
+- **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (WorkManager / Proto DataStore next)
+- **Skills/modes:** Hermes direct dogfood (external spike + docs; no Forma engine DSL change)
+- **External tree:** `/Users/claw/work/nowinandroid-forma/forma-spike`
+  - DataStore: theme brand / dark config / dynamic color keys (F18)
+  - Data: `UserData` theme fields + repository setters
+  - Domain: `GetUserEditableSettings` + update brand/dark/dynamic use cases (F19)
+  - Feature: `feature-settings-{api,res,impl}` — theme radios + privacy/brand/feedback links
+  - **F22:** spike adds settings **api** (upstream was impl-only) for NavKey ports (F1)
+  - Edges: settings.impl → domain only (no other feature); foryou → settings **api**
+  - Root: `SettingsNavKey`; For You “Settings” entry; **6-feature** composition
+- **Verify (real host):**
+  - `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (463 tasks)
+  - APK `binary-debug.apk` ~13 MB
+- **Docs:** `docs/DOGFOOD-NIA.md` phase C Settings + F22; TICKETS F-115 notes; spike README
+- **Commits/PRs:** this branch → PR base `v2`
+- **Blockers:** none product; F-094 Portal still human-blocked
+- **Next:** WorkManager sync and/or Proto DataStore / flavors
+
 ## 2026-07-31 — F-115: NiA dogfood Search feature
 
 - **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (settings / WorkManager next)


### PR DESCRIPTION
## Summary
- F-115 phase C **Settings** on external `nowinandroid-forma/forma-spike`
- Preferences DataStore theme brand / dark / dynamic color (F18)
- Domain use cases only on feature classpath (F19)
- `feature-settings-{api,res,impl}` — **F22** adds settings-api (upstream was impl-only) for F1 nav ports
- Root + For You compose **6 features**; settings.impl has no other feature edges (F5)
- Verify: `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (463 tasks)

## Board
- F-115 remains `in_progress` · `priority: now` · `cron may continue`
- Next: WorkManager sync / Proto DataStore / flavors
- F-094 still human-blocked

## Test plan
- [x] Host `forma-spike` `:binary:assembleDebug` green
- [ ] CI on docs PR