### PR TITLE
F-115: NiA dogfood WorkManager sync + F23/F24

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -172,11 +172,11 @@ External multimodule OSS validation of meta-build axioms (structure over configu
 type-owned plugins, attrs-only call sites, closed matrix). **Not** another in-repo sample.
 
 Open coding: **F-115** (`in_progress`, **`priority: now`**, **cron may continue**). **F-094** Portal remains `blocked` (human).
-4h workers: pick F-115 phase C remainder (WorkManager sync / Proto DataStore / flavors) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
+4h workers: pick F-115 phase C remainder (Proto DataStore / flavors) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C Hilt+Room+Firebase+DataStore+ForYou+Bookmarks+Search+Settings done:** spike green with Hilt Path A + Room Path B + Firebase Path A + Preferences DataStore + **`feature-foryou`** + **`feature-bookmarks`** + **`feature-search`** + **`feature-settings`** (theme brand/dark/dynamic via domain; **F22** settings-api added for F1 ports). Findings F16–F22 (6-feature root). **Next phase C:** WorkManager sync / Proto DataStore / flavors. No `androidLibrary`. |
+| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C through WorkManager sync done:** Hilt Path A + Room Path B + Firebase Path A + Preferences DataStore + ForYou/Bookmarks/Search/Settings + **`sync-work-android-util`** (WorkManager + Hilt Work library stack; binary `Sync.initialize`). Findings F16–F24 (6-feature root + sync leaf). **Next phase C:** Proto DataStore / flavors. No `androidLibrary`. |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/DOGFOOD-NIA.md
+++ b/docs/DOGFOOD-NIA.md
@@ -1,6 +1,6 @@
 # Dogfood: Now in Android → Forma (F-115)
 
-**Status:** `in_progress` — phase C Hilt + Room + Firebase + DataStore + For You + Bookmarks + Search + **Settings feature green** (WorkManager / Proto DataStore next)  
+**Status:** `in_progress` — phase C Hilt + Room + Firebase + DataStore + features + Settings + **WorkManager sync green** (Proto DataStore / flavors next)  
 **Upstream:** [android/nowinandroid](https://github.com/android/nowinandroid) (Apache-2.0)  
 **Pinned checkout (local):** `/Users/claw/work/nowinandroid` @ `7d45eae` (main tip when cloned 2026-07-29)  
 **Dogfood fork:** `/Users/claw/work/nowinandroid-forma`  
@@ -308,7 +308,22 @@ Workspace: same **`forma-spike`** external tree.
 | Root | `SettingsNavKey`; For You “Settings” entry; **6-feature** composition |
 | Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (463 tasks); APK ~13 MB |
 
-**Still open in phase C:** flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+**Still open in phase C (pre-WorkManager):** flavors, full designsystem, Proto DataStore parity, WorkManager sync.
+
+### Phase C — WorkManager sync ✅ (2026-07-31)
+
+| Step | Result |
+|------|--------|
+| Data | `SyncManager` port on `core-data-android-util`; `TopicsRepository`/`NewsRepository.sync()` offline seed refresh |
+| Module | `sync-work-android-util` — `hiltAndroidUtil` leaf (WorkManager + Hilt Work **library stack**, F18 sibling) |
+| Sources | `SyncWorker` + `DelegatingWorker` + `WorkManagerSyncManager` + stub `SyncSubscriber` + `Sync.initialize` |
+| Edges | sync → data only; **binary** → sync (composition root); no feature edge |
+| Binary | `NiaSpikeApp.onCreate` → `Sync.initialize`; version `0.10.0-nia-forma-sync` |
+| **F23** | `androidUtil` forbids `res/` — sync notification copy hardcoded (optional later `androidRes`) |
+| **F24** | `deps()` cannot mix `.ksp` NamedDependency + `target()` in one overload — compose with `+` |
+| Verify | `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (486 tasks); APK ~13 MB |
+
+**Still open in phase C:** flavors, full designsystem, Proto DataStore parity.
 
 ### Phase D — Case study write-up
 
@@ -339,6 +354,8 @@ Workspace: same **`forma-spike`** external tree.
 | F20 | 2026-07-30 | Multi-feature composition at root | foryou + bookmarks + interests + topic: each `impl` only → other feature **api**; root-app/binary compose all four. Start dest = For You (NiA home). Confirms F5 at 4-feature scale. |
 | F21 | 2026-07-31 | Search + 5-feature root | search.impl → topic/interests/foryou **api** only; root composes five features. Recent queries on DataStore (F18). Contains-search over Room (no FTS) still proves matrix + F2. |
 | F22 | 2026-07-31 | Settings upstream impl-only | NiA `:feature:settings:impl` has no api module. Spike adds `settings-api` (SettingsNavKey only) so root/other features navigate via **api** ports (F1) without depending on settings impl. Theme prefs on Preferences DataStore — still no Proto. |
+| F23 | 2026-07-31 | sync work notification strings | `androidUtil` content rule = no `res/`. Spike hardcodes notification title/channel (system sync icon). Optional later: `sync-work-res` `androidRes` + matrix edge. |
+| F24 | 2026-07-31 | `deps()` overload mix | Cannot pass `.ksp` NamedDependency and `target()` FormaTarget in one `deps(...)` call (distinct overloads). Compose `transitiveDeps + deps(ksp) + deps(target)`. |
 
 ## Local reference commands
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,25 @@
 
 Newest entries first.
 
+## 2026-07-31 — F-115: NiA dogfood WorkManager sync
+
+- **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (Proto DataStore / flavors next)
+- **Skills/modes:** Hermes direct dogfood (external spike + docs; no Forma engine DSL change)
+- **External tree:** `/Users/claw/work/nowinandroid-forma/forma-spike`
+  - Data: `SyncManager` port; `TopicsRepository`/`NewsRepository.sync()` offline seed
+  - Module: `sync-work-android-util` — `hiltAndroidUtil` + WorkManager + Hilt Work (F18 library stack)
+  - Workers: `SyncWorker` + `DelegatingWorker` + `WorkManagerSyncManager` + stub subscriber
+  - Binary: `Sync.initialize` in `NiaSpikeApp`; deps → `:sync:work:android-util`
+  - **F23:** no `res/` on androidUtil — hardcoded sync notification copy
+  - **F24:** `deps()` overload split for `.ksp` + `target()`
+- **Verify (real host):**
+  - `forma-spike` `./gradlew :binary:assembleDebug` → **BUILD SUCCESSFUL** (486 tasks)
+  - APK `binary-debug.apk` ~13 MB
+- **Docs:** `docs/DOGFOOD-NIA.md` phase C WorkManager + F23/F24; TICKETS F-115 notes; spike README
+- **Commits/PRs:** this branch → PR base `v2`
+- **Blockers:** none product; F-094 Portal still human-blocked
+- **Next:** Proto DataStore and/or flavors
+
 ## 2026-07-31 — F-115: NiA dogfood Settings feature
 
 - **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (WorkManager / Proto DataStore next)


### PR DESCRIPTION
## Summary
- F-115 phase C **WorkManager sync** on external NiA→Forma spike
- New `sync-work-android-util` (`hiltAndroidUtil`): WorkManager + Hilt Work library stack (F18 sibling — no structure Gradle plugin)
- Data: `SyncManager` port + `TopicsRepository`/`NewsRepository.sync()` offline seed
- Binary: `Sync.initialize` in `NiaSpikeApp`; deps → `:sync:work:android-util`
- Findings **F23** (androidUtil no `res/` → hardcoded sync notification) and **F24** (`deps()` cannot mix `.ksp` + `target()` in one call)

## Verify (host)
```
cd /Users/claw/work/nowinandroid-forma/forma-spike
source /Users/claw/work/forma/scripts/env-mac.sh
./gradlew :binary:assembleDebug
# BUILD SUCCESSFUL (486 tasks); APK ~13 MB
```

## Next
Proto DataStore / flavors. F-115 stays `in_progress` · `priority: now` · `cron may continue`.