### PR TITLE
F-115: NiA dogfood analytics + notifications (docs)

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -172,11 +172,11 @@ External multimodule OSS validation of meta-build axioms (structure over configu
 type-owned plugins, attrs-only call sites, closed matrix). **Not** another in-repo sample.
 
 Open coding: **F-115** (`in_progress`, **`priority: now`**, **cron may continue**). **F-094** Portal remains `blocked` (human).
-4h workers: pick F-115 phase C remainder (remaining cores / optional F27) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
+4h workers: pick F-115 phase C remainder (**F27 library flavors** / Phase D) while gated; if no ticket has `priority: now` / `cron may continue`, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough).
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
-| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C through core:network done:** Hilt Path A + Room Path B + Firebase Path A + Proto DataStore + ForYou/Bookmarks/Search/Settings + WorkManager + binary flavors + designsystem `uiLibrary` + `core:ui` `composeWidget` + **`core:network` demo assets** (F30). Findings F16–F30 (F3 closed DS+ui). **Next phase C:** analytics/notifications / F27. No `androidLibrary`. |
+| F-115 | in_progress · **priority: now** · **cron may continue** | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). **Phase A+B+C through analytics+notifications done:** Hilt/Room/Firebase/Proto DS + features + WM + flavors + designsystem + core:ui + network + **`core:analytics`** + **`core:notifications`{res,util}** (F31). Findings F16–F31. **Next phase C:** F27 library flavors / Phase D case study. No `androidLibrary`. |
 
 ## Backlog (lower priority / historical GitHub)
 

--- a/docs/DOGFOOD-NIA.md
+++ b/docs/DOGFOOD-NIA.md
@@ -1,6 +1,6 @@
 # Dogfood: Now in Android → Forma (F-115)
 
-**Status:** `in_progress` — phase C through **core:network** green (analytics/notifications / F27 next)  
+**Status:** `in_progress` — phase C through **analytics + notifications** green (F27 library flavors next)  
 **Upstream:** [android/nowinandroid](https://github.com/android/nowinandroid) (Apache-2.0)  
 **Pinned checkout (local):** `/Users/claw/work/nowinandroid` @ `7d45eae` (main tip when cloned 2026-07-29)  
 **Dogfood fork:** `/Users/claw/work/nowinandroid-forma`  
@@ -397,7 +397,24 @@ Workspace: same **`forma-spike`** external tree.
 | Verify | `forma-spike` `:binary:assembleDemoDebug` + `:binary:assembleProdDebug` → **BUILD SUCCESSFUL** (581 tasks); APKs ~22 MB |
 | Version | `0.15.0-nia-forma-network` |
 
-**Still open in phase C:** optional remaining cores (analytics/notifications); F27 library flavors.
+**Still open in phase C (pre-analytics):** F27 library flavors — superseded by analytics/notifications section below.
+
+### Phase C — core:analytics + core:notifications ✅ (2026-08-01)
+
+| Step | Result |
+|------|--------|
+| Module | `core-analytics-android-util` — `AnalyticsHelper` / `AnalyticsEvent` / Stub + NoOp + `LocalAnalyticsHelper` |
+| Type | plain **`hiltAndroidUtil`** + Compose **runtime** library stack for CompositionLocal (**F18** sibling; `compose=false` target — F11) |
+| Bind | **StubAnalyticsHelper** for **all** product flavors (F27 prod `FirebaseAnalyticsHelper` + flavor source sets deferred) |
+| Module | `core-notifications-res` **`androidRes`** + `core-notifications-android-util` **`hiltAndroidUtil`** |
+| **F31 / F23** | Tray strings + vector icon on **res** module (unique namespace `…notifications.res`); util imports `R as NotificationsR` — androidUtil still no `res/` |
+| Bind | **SystemTrayNotifier** for all flavors (validates res split + data edge; demo NoOp deferred with F27) |
+| Data | UserData toggles → analytics events; News `sync()` → notifier for new followed-topic items after onboard |
+| UI | `core-ui` → analytics; NewsFeed logs `news_resource_opened`; root `CompositionLocalProvider` + `TrackScreenViewEvent` |
+| Verify | `forma-spike` `:binary:assembleDemoDebug` + `:binary:assembleProdDebug` → **BUILD SUCCESSFUL** (645 tasks); APKs ~22 MB |
+| Version | `0.16.0-nia-forma-analytics-notifications` |
+
+**Still open in phase C:** F27 library flavors / prod Firebase analytics + demo NoOp notifier source sets; optional case-study Phase D.
 
 ### Phase D — Case study write-up
 
@@ -414,6 +431,7 @@ Workspace: same **`forma-spike`** external tree.
 | F3 | 2026-07-29 | ui → model vs uiLibrary matrix | **Closed for designsystem 2026-08-01** and **core.ui 2026-08-01:** designsystem `uiLibrary` model-free; core.ui uses `composeWidget` + presentation DTOs (no model edge). Model still flows `impl` → JVM `library` only. |
 | F28 | 2026-08-01 | designsystem Coil/icons/adaptive | No structure Gradle plugin — companions are **library stack** on `uiLibrary` via `transitiveDeps` (F18 sibling). Type remains plain `uiLibrary`. |
 | F29 | 2026-08-01 | core.ui type + model | **`composeWidget`** (suffix `compose-widget`) depends on designsystem `ui-library` (matrix). Shared cards take `NewsResourceCardUi` DTOs; features own model→DTO mapping. Rejects second `uiLibrary` (no self-edge) and rejects matrix weaken `uiLibrary`→`library`. |
+| F31 | 2026-08-01 | notifications res vs androidUtil | **Closed:** `core-notifications-res` (`androidRes`, namespace `…notifications.res`) + util → res edge. AGP requires unique namespace vs util. Validates F23 with real tray notifier (not only hardcoded sync copy). |
 | F30 | 2026-08-01 | network kotlinx.serialization | Demo network uses `kotlinx-serialization-json` as **library stack** on `hiltAndroidUtil` (manual Json element parse). No `org.jetbrains.kotlin.plugin.serialization` structure plugin for dogfood demo path. Retrofit/prod + flavor source sets remain F27. |
 | F5 | 2026-07-29 | test / runtime impl→impl | **Phase C runtime:** interests.impl → topic.**api** only. Test classpath still deferred |
 | F8 | 2026-07-29 | upstream topic **api** ships `res/strings` | **Spike:** `feature/topic/res` `androidRes`; `api` has no `res/` (matrix content rule) |
@@ -435,7 +453,7 @@ Workspace: same **`forma-spike`** external tree.
 | F24 | 2026-07-31 | `deps()` overload mix | Cannot pass `.ksp` NamedDependency and `target()` FormaTarget in one `deps(...)` call (distinct overloads). Compose `transitiveDeps + deps(ksp) + deps(target)`. |
 | F25 | 2026-07-31 | Protobuf needs type-owned apply on JVM library | NiA `datastore-proto` is pure JVM + `com.google.protobuf`. Engine needed `libraryTarget` (like `androidUtilTarget`) so Path B `protobufLibrary` can pass derived type. Call sites stay attrs-only. |
 | F26 | 2026-07-31 | Proto lite supers on consumers | `UserPreferences` / enums extend protobuf lite; androidUtil consumer must `transitiveDeps(protobuf-kotlin-lite)` even when proto module already depends on it (project dep does not re-export non-api runtime the same way as NiA `api(libs.protobuf…)`). |
-| F27 | 2026-07-31 | Library product flavors / variant deps | Binary-only `FormaProductFlavor` closes F7 for APK. NiA also flavors libraries + `prodImplementation(FCM)` on sync. v1 leaves libraries unflavored (AGP resolves). Future: optional library flavor attrs or type-owned missingDimensionStrategy — do **not** put free-form `android { productFlavors }` on every module. |
+| F27 | 2026-07-31 | Library product flavors / variant deps | Binary-only `FormaProductFlavor` closes F7 for APK. NiA also flavors libraries + `prodImplementation(FCM)` on sync + **analytics demo/prod binds** + **notifications demo NoOp / prod tray**. Spike binds Stub analytics + SystemTray notifier for **all** flavors until library flavor attrs exist. Future: optional library flavor attrs or type-owned missingDimensionStrategy — do **not** put free-form `android { productFlavors }` on every module. |
 
 ## Local reference commands
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,26 @@
 
 Newest entries first.
 
+## 2026-08-01 — F-115: NiA dogfood core:analytics + core:notifications
+
+- **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (F27 library flavors / Phase D next)
+- **Skills/modes:** Hermes direct dogfood (external spike + docs; no Forma engine DSL change; no Grok Build)
+- **External tree:** `/Users/claw/work/nowinandroid-forma/forma-spike`
+  - `core-analytics-android-util`: **`hiltAndroidUtil`** — AnalyticsHelper + Stub bind (all flavors); LocalAnalyticsHelper
+  - `core-notifications-res`: **`androidRes`** — strings + vector icon (unique namespace `…notifications.res`)
+  - `core-notifications-android-util`: **`hiltAndroidUtil`** — Notifier + SystemTrayNotifier → res + model
+  - Data: UserData analytics events; News sync → tray notify for new followed-topic items after onboard
+  - UI/root: NewsFeed open events; CompositionLocalProvider + TrackScreenViewEvent
+  - **F31:** res split for notifications (F23 sibling); F27 still covers flavor-specific binds
+  - version `0.16.0-nia-forma-analytics-notifications`
+- **Verify (real host, JDK 21):**
+  - `forma-spike` `./gradlew :binary:assembleDemoDebug :binary:assembleProdDebug` → **BUILD SUCCESSFUL** (645 tasks)
+  - APKs under `binary/build/outputs/apk/{demo,prod}/debug/`
+- **Docs:** `docs/DOGFOOD-NIA.md` phase C analytics/notifications + F31; TICKETS F-115 notes; spike README
+- **Commits/PRs:** this branch → PR base `v2`
+- **Blockers:** none product; F-094 Portal still human-blocked
+- **Next:** F27 library flavors (analytics prod Firebase / notifications demo NoOp) or Phase D case study
+
 ## 2026-08-01 — F-115: NiA dogfood core:network demo data source
 
 - **Ticket:** F-115 still `in_progress` · `priority: now` · `cron may continue` (analytics/notifications / F27 next)


### PR DESCRIPTION
## Summary
- F-115 phase C: port **core:analytics** + **core:notifications** on external NiA Forma spike (`forma-spike`).
- Analytics: `hiltAndroidUtil` facade + Stub bind (all flavors until F27); `LocalAnalyticsHelper` + UI open/screen events.
- Notifications: **`androidRes`** (unique namespace) + **`hiltAndroidUtil`** SystemTrayNotifier (F23/F31); data sync posts new followed-topic news after onboard.
- Verify: `./gradlew :binary:assembleDemoDebug :binary:assembleProdDebug` → BUILD SUCCESSFUL (645 tasks); APKs ~22 MB; version `0.16.0-nia-forma-analytics-notifications`.
- Docs: `DOGFOOD-NIA.md` + F31 finding; board notes; PROGRESS. No engine DSL change.

## Test plan
- [x] Host JDK 21 spike assembleDemoDebug + assembleProdDebug
- [ ] CI docs-only on forma repo