### PR TITLE
P13: promote remaining open GH backlog into TICKETS

### DIFF
--- a/TICKETS.md
+++ b/TICKETS.md
@@ -171,12 +171,23 @@ composition stays at Android/JVM roots. iOS/JS/Wasm = later phase.
 External multimodule OSS validation of meta-build axioms (structure over configuration,
 type-owned plugins, attrs-only call sites, closed matrix). **Not** another in-repo sample.
 
-Open coding: **none gated** after F-115 done. **F-094** Portal remains `blocked` (human).
+Open coding after promote: **F-116** (gated). **F-094** Portal remains `blocked` (human).
 4h workers: if no ticket has `todo`/`in_progress` with **`priority: now`** / **`cron may continue`**, respond `[SILENT]` (audit 2026-07-29 gate — interactive “Go ahead” alone is not enough). Do not invent tickets.
 
 | ID | Status | Title | Notes |
 |----|--------|-------|-------|
 | F-115 | done | Dogfood Now in Android under Forma | Primary OSS target [`android/nowinandroid`](https://github.com/android/nowinandroid). Design: [`docs/DOGFOOD-NIA.md`](docs/DOGFOOD-NIA.md). Case study: [`docs/DOGFOOD-NIA-CASE-STUDY.md`](docs/DOGFOOD-NIA-CASE-STUDY.md). **Phase A–D complete:** external mavenLocal spike green (`assembleDemoDebug`/`ProdDebug`); Hilt/Room/Firebase/Proto DS + features + WM + flavors (F7/F27) + designsystem/core.ui/network/analytics/notifications; findings F1–F31; module scripts **−59%** LOC vs upstream. No `androidLibrary`. Optional parity leftovers = new tickets only. |
+
+## P13 — Promoted GH backlog (2026-08-06 Stepan)
+
+Promoted remaining open historical GitHub issues after empty post–F-115 queue.
+Workers pick top `todo` in order. **Still not product tickets:** `v2`→`master` (explicit git promote only); case-study residual NiA parity (includer publish, Retrofit prod network, test graph, Roborazzi/fleet tooling) — open as new F-xxx only if prioritized separately. **F-094** stays `blocked`.
+
+Hygiene this promote: closed GH **#46** (nav — F-102/111/112) and **#43** (hybrid — F-103/104) as already landed on `v2`.
+
+| ID | Status | Title | Notes |
+|----|--------|-------|-------|
+| F-116 | todo | Sample clean architecture (domain use cases) | GH **#48** · **`priority: now`** · **`cron may continue`**. Gold sample: weaken presentation↔data coupling via **domain use cases**; kill `GlobalScope` / data-layer scope ownership (see legacy `CharacterPageDataSource` / `CharactersListViewModel` pattern if still present). Keep flat role graph — domain as `api`/`impl` (or util) ports, no `impl`→`impl`, no `androidLibrary`. Docs: `docs/SAMPLE-APP.md` + any progressive pointer if teaching-worthy. Close #48 on merge. |
 
 ## Backlog (lower priority / historical GitHub)
 
@@ -193,15 +204,15 @@ Keep for reference; do not start unless higher tickets done or user prioritizes:
 - ~~GH #77 transitiveDeps extension~~ → **F-096**
 - GH #54 Generate target structure from minimal config → **theme under F-084 / F-088**
 - ~~GH #51 Support build types~~ → **F-097**
-- ~~GH #46 New navigation system~~ → **F-102** design + **F-111** sample + **F-112** example **done**
+- ~~GH #46 New navigation system~~ → **F-102** design + **F-111** sample + **F-112** example **done** (GH closed 2026-08-06)
 - ~~GH #44 Hybrid targets example~~ → **F-103**
-- ~~GH #43 Hybrid configuration example~~ → **F-104**
+- ~~GH #43 Hybrid configuration example~~ → **F-104** (GH closed 2026-08-06)
 - GH #36 Docs for external plugins → **P7 / F-070–F-073**
 - ~~GH #126 Target features configuration options~~ → **F-099**
 - ~~GH #111 Gradle project as buildscript classpath~~ → **F-100**
 - ~~GH #103 Java 8+ API on Android API ≤26~~ → **F-098**
 - ~~GH #56 Implement targets deps APIs~~ → **F-101**
-- GH #48 Clean sample architecture (domain use cases) — sample quality only; not meta-build; leave unpromoted unless prioritized
+- ~~GH #48 Clean sample architecture (domain use cases)~~ → **F-116** (promoted 2026-08-06)
 
 ## How workers update this file
 

--- a/docs/PROGRESS.md
+++ b/docs/PROGRESS.md
@@ -2,6 +2,17 @@
 
 Newest entries first.
 
+## 2026-08-06 — P13: promote remaining open GH into TICKETS
+
+- **Context:** Empty gated coding board post F-115/#250; Stepan: **Promote gh issues**
+- **Open GH audit:** only **#133** (Portal), **#48** (sample clean arch), **#46** (nav), **#43** (hybrid)
+- **Hygiene:** closed **#46** (done via F-102/111/112) and **#43** (done via F-103/104) with comments pointing at `v2` docs/examples
+- **Promoted:** **F-116** ← GH **#48** sample domain use cases / clean architecture · `todo` · **`priority: now`** · **`cron may continue`**
+- **Left open / blocked:** **#133** = **F-094** (human Portal org/user)
+- **Not promoted as tickets:** `v2`→`master`; optional NiA case-study residuals (includer publish, Retrofit prod, test graph, Roborazzi/fleet) — still residual list in `docs/DOGFOOD-NIA-CASE-STUDY.md` §7
+- **Docs:** `TICKETS.md` P13 + backlog strikes; this PROGRESS entry
+- **Next:** 4h / interactive pickup **F-116**; F-094 still human-blocked
+
 ## 2026-08-03 — NiA migration perf benchmark (post F-115)
 
 - **Context:** F-115 done; user asked to run tests + understand perf implications of the migration and create a benchmark


### PR DESCRIPTION
## Summary
- Promotes last open product GH backlog into **P13** on `TICKETS.md` so 4h workers leave idle/`[SILENT]` after F-115.
- **F-116** ← GH **#48** sample domain clean architecture · `todo` · **`priority: now`** · **`cron may continue`**
- **F-094** / GH **#133** Portal stays `blocked` (human)
- Hygiene: closed landed GH **#46** (nav F-102/111/112) and **#43** (hybrid F-103/104) with comments
- Docs-only: `TICKETS.md` + `docs/PROGRESS.md`

## Not promoted
- `v2`→`master` (explicit only)
- Optional NiA case-study §7 residuals (includer publish, Retrofit prod, test graph, Roborazzi/fleet) — separate ask

## Test plan
- [x] Board has gated `todo` (F-116)
- [x] Open GH after hygiene: #48 + #133 only
- [ ] CI green on docs-only PR